### PR TITLE
fix: resolve TZID events via VTIMEZONE table

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -151,10 +151,150 @@ function weekdayOfKey(key) {
   return new Date(Date.UTC(p.y, p.mo - 1, p.d)).getUTCDay()
 }
 
+// --- VTIMEZONE offset table -------------------------------------------------
+// QML's V4 engine has no Intl, so named zones must be resolved from the
+// VTIMEZONE blocks the feed itself ships.
+
+var TZ_TABLE = {}
+
+function parseTzOffset(value) {
+  var m = /^([+-])(\d{2})(\d{2})(\d{2})?$/.exec(String(value || "").trim())
+  if (!m) return null
+  var sign = m[1] === "-" ? -1 : 1
+  var mins = parseInt(m[2], 10) * 60 + parseInt(m[3], 10)
+  var secs = m[4] ? parseInt(m[4], 10) : 0
+  return sign * (mins * 60 + secs) * 1000
+}
+
+// Collect TZID -> observances from raw (already unfolded) ICS lines.
+function registerVTimezones(lines) {
+  var tzid = null
+  var inTz = false
+  var obs = null
+  var list = null
+  for (var i = 0; i < lines.length; i++) {
+    var line = String(lines[i]).trim()
+    if (!line) continue
+    if (line === "BEGIN:VTIMEZONE") { inTz = true; tzid = null; list = []; continue }
+    if (!inTz) continue
+    if (line === "END:VTIMEZONE") {
+      if (tzid && list && list.length) TZ_TABLE[tzid] = list
+      inTz = false; tzid = null; list = null; obs = null
+      continue
+    }
+    if (line === "BEGIN:STANDARD" || line === "BEGIN:DAYLIGHT") {
+      obs = { daylight: line === "BEGIN:DAYLIGHT", from: null, to: null, wall: null, rule: null }
+      continue
+    }
+    if (line === "END:STANDARD" || line === "END:DAYLIGHT") {
+      if (obs && obs.to !== null && obs.wall) {
+        if (obs.from === null) obs.from = obs.to
+        list.push(obs)
+      }
+      obs = null
+      continue
+    }
+    var prop = splitProperty(line)
+    if (!prop) continue
+    if (!obs) {
+      if (prop.name === "TZID") tzid = prop.value.trim()
+      continue
+    }
+    if (prop.name === "TZOFFSETFROM") obs.from = parseTzOffset(prop.value)
+    else if (prop.name === "TZOFFSETTO") obs.to = parseTzOffset(prop.value)
+    else if (prop.name === "DTSTART") {
+      var w = /^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})?)?/.exec(prop.value.trim())
+      if (w) obs.wall = {
+        y: parseInt(w[1], 10), mo: parseInt(w[2], 10), d: parseInt(w[3], 10),
+        h: w[4] ? parseInt(w[4], 10) : 0,
+        mi: w[5] ? parseInt(w[5], 10) : 0,
+        s: w[6] ? parseInt(w[6], 10) : 0
+      }
+    }
+    else if (prop.name === "RRULE") {
+      var r = { month: 0, weekday: -1, ord: 0, monthday: 0 }
+      var segs = prop.value.split(";")
+      for (var k = 0; k < segs.length; k++) {
+        var kv = segs[k].split("=")
+        var key = String(kv[0] || "").toUpperCase()
+        var val = String(kv[1] || "").trim()
+        if (key === "BYMONTH") r.month = parseInt(val, 10) || 0
+        else if (key === "BYMONTHDAY") r.monthday = parseInt(val, 10) || 0
+        else if (key === "BYDAY") {
+          var bd = /^(-?\d+)?(SU|MO|TU|WE|TH|FR|SA)$/.exec(val.split(",")[0].trim())
+          if (bd) {
+            r.ord = bd[1] ? parseInt(bd[1], 10) : 1
+            r.weekday = WEEKDAY[bd[2]]
+          }
+        }
+      }
+      if (r.month) obs.rule = r
+    }
+  }
+}
+
+function nthWeekdayOfMonth(y, mo, weekday, ord) {
+  var dim = daysInMonthUTC(y, mo)
+  if (ord > 0) {
+    var firstDow = new Date(Date.UTC(y, mo - 1, 1)).getUTCDay()
+    var day = 1 + ((weekday - firstDow + 7) % 7) + (ord - 1) * 7
+    return day <= dim ? day : 0
+  }
+  if (ord < 0) {
+    var lastDow = new Date(Date.UTC(y, mo - 1, dim)).getUTCDay()
+    var day2 = dim - ((lastDow - weekday + 7) % 7) + (ord + 1) * 7
+    return day2 >= 1 ? day2 : 0
+  }
+  return 0
+}
+
+// Transition instants for a zone, expressed in that zone's wall clock (the
+// space RFC 5545 observance DTSTARTs live in), for the years around `year`.
+function zoneTransitions(list, year) {
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var obs = list[i]
+    if (!obs.rule) {
+      out.push({ wallMs: Date.UTC(obs.wall.y, obs.wall.mo - 1, obs.wall.d, obs.wall.h, obs.wall.mi, obs.wall.s), from: obs.from, to: obs.to })
+      continue
+    }
+    for (var y = year - 1; y <= year + 1; y++) {
+      if (y < obs.wall.y) continue
+      var day = obs.rule.monthday
+        ? Math.min(obs.rule.monthday, daysInMonthUTC(y, obs.rule.month))
+        : nthWeekdayOfMonth(y, obs.rule.month, obs.rule.weekday, obs.rule.ord)
+      if (!day) continue
+      out.push({ wallMs: Date.UTC(y, obs.rule.month - 1, day, obs.wall.h, obs.wall.mi, obs.wall.s), from: obs.from, to: obs.to })
+    }
+  }
+  out.sort(function (a, b) { return a.wallMs - b.wallMs })
+  return out
+}
+
+// Offset in ms that applies to the given wall-clock time in `tzid`,
+// or null when the zone is unknown.
+function tzOffsetForWall(tzid, y, mo, d, h, mi, s) {
+  var list = TZ_TABLE[tzid]
+  if (!list || !list.length) return null
+  var wallMs = Date.UTC(y, mo - 1, d, h, mi, s)
+  var trans = zoneTransitions(list, y)
+  if (!trans.length) return null
+  var off = trans[0].from
+  for (var i = 0; i < trans.length; i++) {
+    if (wallMs >= trans[i].wallMs) off = trans[i].to
+    else break
+  }
+  return off === null ? null : off
+}
+
 // Convert a "local" wall-clock { y, mo, d, h, mi, s } to a UTC Date.
-// TZID: try Intl-aware conversion, fall back to naive local handling.
+// TZID resolution order: VTIMEZONE table, then Intl if the engine has it,
+// then naive local handling as a last resort.
 function zonedToUtc(tzid, y, mo, d, h, mi, s) {
+  var tableOffset = tzOffsetForWall(tzid, y, mo, d, h, mi, s)
+  if (tableOffset !== null) return new Date(Date.UTC(y, mo - 1, d, h, mi, s) - tableOffset)
   try {
+    if (typeof Intl === "undefined") throw new Error("no Intl")
     var guess = new Date(Date.UTC(y, mo - 1, d, h, mi, s))
     var formatter = new Intl.DateTimeFormat("en-US", {
       timeZone: tzid,
@@ -490,6 +630,7 @@ function parseIcs(raw, options) {
   var fromKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
 
   var lines = unfoldIcs(raw)
+  registerVTimezones(lines)
   var blocks = []
   var current = null
   for (var i = 0; i < lines.length; i++) {
@@ -814,6 +955,9 @@ if (typeof module !== "undefined" && module.exports) {
     upcomingToday: upcomingToday,
     eventCalendarUrl: eventCalendarUrl,
     hm: hm,
-    timeRange: timeRange
+    timeRange: timeRange,
+    registerVTimezones: registerVTimezones,
+    tzOffsetForWall: tzOffsetForWall,
+    zonedToUtc: zonedToUtc
   }
 }


### PR DESCRIPTION
## Problem

Events whose `DTSTART` carries a `TZID` other than the viewer's system zone are shown at the wrong time.

`zonedToUtc()` resolves named zones with `Intl.DateTimeFormat`, wrapped in a `try`/`catch` that falls back to `new Date(y, mo - 1, d, h, mi, s)`. **QML's V4 engine does not implement `Intl`** — `typeof Intl === "undefined"`, confirmed on Qt 6.11.1:

```qml
import QtQuick
Item {
  Component.onCompleted: {
    var code = (typeof Intl === "undefined") ? 42 : 50
    Qt.exit(code)   // -> 42
  }
}
```

So the `catch` branch runs for *every* `TZID` event, and it reinterprets the event's wall clock as the viewer's local wall clock. The offset error equals the difference between the two zones:

| Event | Viewer zone | Correct | Shown before |
| --- | --- | --- | --- |
| `DTSTART;TZID=America/New_York:20260818T130000` | `America/Anchorage` | 09:00 | 13:00 |
| `DTSTART;TZID=Europe/London:20260818T130000` | `America/Anchorage` | 04:00 | 13:00 |

Anyone whose calendar is authored in a different zone than their machine sees this: a Google Workspace calendar keeps each event's original `TZID`, so a US-East work calendar viewed from Alaska is off by four hours on the bar label, the NEXT card, and every row of the schedule list. Viewers whose events all carry their own system zone are unaffected, which is why this hides so well.

## Fix

Resolve named zones from the `VTIMEZONE` blocks the feed already ships — no `Intl`, no external tz database, no new dependency. Google Calendar emits a `VTIMEZONE` for every `TZID` its events reference.

- `registerVTimezones()` collects `TZID` → `STANDARD`/`DAYLIGHT` observances (`TZOFFSETFROM`/`TZOFFSETTO`, `DTSTART`, yearly `BYMONTH` + `BYDAY`/`BYMONTHDAY` rules). Called from `parseIcs()` on the unfolded lines before any `VEVENT` is parsed, so ordering within the feed does not matter.
- `zoneTransitions()` materialises transitions for the target year ±1 in the zone's own wall-clock space — which is where RFC 5545 observance `DTSTART`s live.
- `tzOffsetForWall()` returns the offset in effect for a wall-clock time, or `null` for an unknown zone.
- `zonedToUtc()` now tries the table first, then `Intl` where an engine has it (Node, tests), then the previous naive fallback for zones with no `VTIMEZONE`. Nothing that worked before regresses.

## Verification

- **6300 wall-clock round-trips** — `America/New_York`, `America/Anchorage`, `Europe/London` × 2024–2028 × 5 days/month × 7 hours/day. Each wall time is converted to UTC through the new table, then formatted back into its zone with `Intl` (running under Node, where `Intl` exists) and compared against the input. All match, except five wall times that sit inside a spring-forward gap (e.g. `02:30` on 2024-03-10 in New York) — those local times do not exist and no event can start at one.
- **In the real V4 engine** — a probe QML file importing `Model.js` parses a 13:00 `America/New_York` event under `TZ=America/Anchorage` and reports `start.getHours() === 9`. Before this patch the same probe reports `13`.
- **Against a live Google Workspace feed** with `Intl` deleted to simulate V4: a 13:00 New York recurring meeting resolves to 09:00 local, and events already tagged with the system zone are unchanged.
- DST is handled on both sides of each transition, including the recurrence expansion path (`dateForKey()` calls `zonedToUtc()` per occurrence, so a weekly series spanning a DST boundary keeps its local wall time).

## Suggestion: make the display timezone configurable

Worth a separate change, but this bug surfaced the need. Right now the widget always renders in the machine's local zone via `getHours()`/`getMinutes()`. That is the right default, but it is not always what people want — a lot of remote work happens on a calendar authored in the team's zone, and "my 9am standup" is easier to reason about as `12:00 EDT` when the rest of the team says 12:00.

A `timezone` setting alongside the existing widget settings would cover it:

```sh
omarchy bar set next-event timezone America/New_York   # default: system local
```

With this PR's table already in place, the read side is most of the way there: `hm()` and friends would format via a `tzOffsetForWall()` lookup instead of `getHours()`, falling back to system local when the setting is empty or the zone is not in the feed. The one gap is that the table only knows zones the feed ships, so an arbitrary configured zone would need either a `VTIMEZONE` present in the feed or a small bundled offset table.

Happy to implement it as a follow-up PR if you like the shape — and equally happy to adjust the naming or the fallback behaviour here if you would rather it worked differently.
