### PR TITLE
feat: support Zoom, Teams, Webex and GoToMeeting video links

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -409,9 +409,30 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
 
 // --- event block parsing ---------------------------------------------------
 
+var VIDEO_PROVIDERS = [
+  { re: /https:\/\/meet\.google\.com\/[a-z0-9][a-z0-9-]*/, label: "Meet" },
+  { re: /https?:\/\/(?:[\w-]+\.)?zoom\.us\/(?:j|w)\/\d+(?:\?[^\s]*)*/, label: "Video" },
+  { re: /https?:\/\/(?:teams\.microsoft\.com|teams\.live\.com)\/(?:l\/meetup-join|meet|dl\/launcher)\/[^\s]*/, label: "Video" },
+  { re: /https?:\/\/(?:[\w-]+\.)?webex\.com\/(?:meet|j\.php)[^\s]*/, label: "Video" },
+  { re: /https?:\/\/(?:[\w-]+\.)?gotomeeting\.com\/join\/\d+/, label: "Video" },
+]
+
 function findMeetUrl(text) {
-  var m = /https:\/\/meet\.google\.com\/[a-z0-9][a-z0-9-]*/.exec(String(text || ""))
-  return m ? m[0] : null
+  var s = String(text || "")
+  for (var i = 0; i < VIDEO_PROVIDERS.length; i++) {
+    var m = VIDEO_PROVIDERS[i].re.exec(s)
+    if (m) return m[0]
+  }
+  return null
+}
+
+function meetLabel(url) {
+  if (!url) return "Video"
+  var s = String(url)
+  for (var i = 0; i < VIDEO_PROVIDERS.length; i++) {
+    if (VIDEO_PROVIDERS[i].re.test(s)) return VIDEO_PROVIDERS[i].label
+  }
+  return "Video"
 }
 
 function parseEventBlock(block) {
@@ -799,6 +820,8 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     unfoldIcs: unfoldIcs,
     unescapeIcs: unescapeIcs,
+    findMeetUrl: findMeetUrl,
+    meetLabel: meetLabel,
     parseRfcDate: parseRfcDate,
     parseRRule: parseRRule,
     parseIcs: parseIcs,

--- a/Panel.qml
+++ b/Panel.qml
@@ -287,7 +287,7 @@ Panel {
                       var parts = []
                       var dur = root.next ? Model.formatDuration(root.next.start, root.next.end) : ""
                       if (dur) parts.push(dur)
-                      if (root.next) parts.push(root.next.meetUrl ? "  Meet" : "󰃯  Event")
+                      if (root.next) parts.push(root.next.meetUrl ? "  " + Model.meetLabel(root.next.meetUrl) : "󰃯  Event")
                       return parts.join("  ·  ")
                     }
                     color: root.inMeeting ? Color.accent : Qt.darker(root.contentForeground, 1.4)


### PR DESCRIPTION
Extend findMeetUrl() with a VIDEO_PROVIDERS table covering five
providers (Google Meet, Zoom, MS Teams, Webex, GoToMeeting).  Any
event whose join URL matches is treated identically to a Meet event:
meetUrl is populated, buildUpcoming()'s showOnlyWithVideoLink filter
passes, and the glyph / join action work unchanged.

Add meetLabel(url) to return the provider-aware badge text:
'Meet' for Google Meet, 'Video' for all other providers.
Panel.qml uses Model.meetLabel() so the badge is always accurate.

Fixes: Zoom/Teams events being silently filtered from the bar widget
when showOnlyWithVideoLink (default: true) is enabled.
<img width="588" height="697" alt="image" src="https://github.com/user-attachments/assets/fa692038-5f4b-4556-b718-6ad47c57feb5" />

