### PR TITLE
test/vtimezone offset table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+Omarchy (Quickshell) bar-widget plugin that shows the next calendar event and
+lets you click to join Google Meet. NOT a Node app — the runtime is QML.
+
+## Architecture
+
+- `manifest.json` is the plugin descriptor; `entryPoints.barWidget` = `BarWidget.qml`. `kinds: ["bar-widget"]`.
+- QML layer: `BarWidget.qml` (bar widget, ~276 lines) and `Panel.qml` (agenda panel, ~532 lines). These own all Qt/Quickshell UI, fetching (Quickshell.Io), and widget settings.
+- `Model.js` is the pure-JS core: iCalendar parsing, RRULE/DTSTART recurrence expansion, VTIMEZONE/DST handling, display labels. No Qt/Quickshell imports.
+- Model.js is imported two ways: QML does `import "Model.js" as Model`; Node does `require("./Model.js")` for tests. Keep every function top-level (QML exposes them directly) and keep the `module.exports` guard at the bottom — the guard is what makes it require-able in Node.
+
+## Critical runtime constraint
+
+- QML's V4 engine has **no `Intl`**. Model.js must work without it. Timezone resolution order is: VTIMEZONE table → `Intl` if the engine has it → naive local fallback. Do not add `Intl`-dependent logic to Model.js without a fallback (there is a dedicated test simulating the no-Intl engine).
+- TZID table (`TZ_TABLE`) is reset at the start of every `parseIcs`/`registerVTimezones`. A feed that drops a zone must not resolve against stale data — this is a tested invariant; don't make the table accumulate across parses.
+- Keep Model.js dependency-free (pure). The QML sandbox cannot load npm packages; runtime deps are not possible.
+
+## Tests
+
+```sh
+npm test          # node --test "test/*.test.js"
+```
+
+Only one suite: `test/timezones.test.js`. It covers `parseTzOffset`, VTIMEZONE
+DST transitions (BYDAY incl. negative ordinals, BYMONTHDAY), `zonedToUtc`
+round-trips against the system tz database, no-Intl fallback, per-parse table
+reset, and end-to-end `parseIcs` with `TZID` events. Add new model logic to
+this file using the existing `block()`/`register()` helpers. No lint,
+formatter, or typecheck is configured.
+
+## Workflow conventions
+
+- Contributions follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...) and a strictly linear history (rebase, no merge commits). See README's Contributing section.
+- Widget settings are configured via `omarchy bar set tobiasz-p.next-event <key> <value>`; defaults live in the README table (e.g. `icsUrl`, `refreshMinutes`, `showDaysAhead`).

--- a/Model.js
+++ b/Model.js
@@ -155,19 +155,30 @@ function weekdayOfKey(key) {
 // QML's V4 engine has no Intl, so named zones must be resolved from the
 // VTIMEZONE blocks the feed itself ships.
 
+// RFC 5545 offset/rule units, and how far either side of a target year the
+// transition search must look (DST observances always repeat yearly).
+var MS_PER_SECOND = 1000
+var SECONDS_PER_MINUTE = 60
+var MINUTES_PER_HOUR = 60
+var DAYS_PER_WEEK = 7
+var TRANSITION_YEAR_MARGIN = 1
+
 var TZ_TABLE = {}
 
+// Parse an RFC 5545 UTC offset ([+-]HHMM[SS]) into milliseconds.
 function parseTzOffset(value) {
   var m = /^([+-])(\d{2})(\d{2})(\d{2})?$/.exec(String(value || "").trim())
   if (!m) return null
   var sign = m[1] === "-" ? -1 : 1
-  var mins = parseInt(m[2], 10) * 60 + parseInt(m[3], 10)
-  var secs = m[4] ? parseInt(m[4], 10) : 0
-  return sign * (mins * 60 + secs) * 1000
+  var minutes = parseInt(m[2], 10) * MINUTES_PER_HOUR + parseInt(m[3], 10)
+  var seconds = m[4] ? parseInt(m[4], 10) : 0
+  return sign * (minutes * SECONDS_PER_MINUTE + seconds) * MS_PER_SECOND
 }
 
 // Collect TZID -> observances from raw (already unfolded) ICS lines.
+// Reset the table so it reflects only the current feed's VTIMEZONE blocks.
 function registerVTimezones(lines) {
+  TZ_TABLE = {}
   var tzid = null
   var inTz = false
   var obs = null
@@ -183,7 +194,7 @@ function registerVTimezones(lines) {
       continue
     }
     if (line === "BEGIN:STANDARD" || line === "BEGIN:DAYLIGHT") {
-      obs = { daylight: line === "BEGIN:DAYLIGHT", from: null, to: null, wall: null, rule: null }
+      obs = { from: null, to: null, wall: null, rule: null }
       continue
     }
     if (line === "END:STANDARD" || line === "END:DAYLIGHT") {
@@ -237,12 +248,12 @@ function nthWeekdayOfMonth(y, mo, weekday, ord) {
   var dim = daysInMonthUTC(y, mo)
   if (ord > 0) {
     var firstDow = new Date(Date.UTC(y, mo - 1, 1)).getUTCDay()
-    var day = 1 + ((weekday - firstDow + 7) % 7) + (ord - 1) * 7
+    var day = 1 + ((weekday - firstDow + DAYS_PER_WEEK) % DAYS_PER_WEEK) + (ord - 1) * DAYS_PER_WEEK
     return day <= dim ? day : 0
   }
   if (ord < 0) {
     var lastDow = new Date(Date.UTC(y, mo - 1, dim)).getUTCDay()
-    var day2 = dim - ((lastDow - weekday + 7) % 7) + (ord + 1) * 7
+    var day2 = dim - ((lastDow - weekday + DAYS_PER_WEEK) % DAYS_PER_WEEK) + (ord + 1) * DAYS_PER_WEEK
     return day2 >= 1 ? day2 : 0
   }
   return 0
@@ -258,7 +269,7 @@ function zoneTransitions(list, year) {
       out.push({ wallMs: Date.UTC(obs.wall.y, obs.wall.mo - 1, obs.wall.d, obs.wall.h, obs.wall.mi, obs.wall.s), from: obs.from, to: obs.to })
       continue
     }
-    for (var y = year - 1; y <= year + 1; y++) {
+    for (var y = year - TRANSITION_YEAR_MARGIN; y <= year + TRANSITION_YEAR_MARGIN; y++) {
       if (y < obs.wall.y) continue
       var day = obs.rule.monthday
         ? Math.min(obs.rule.monthday, daysInMonthUTC(y, obs.rule.month))

--- a/Model.js
+++ b/Model.js
@@ -968,6 +968,7 @@ if (typeof module !== "undefined" && module.exports) {
     hm: hm,
     timeRange: timeRange,
     registerVTimezones: registerVTimezones,
+    parseTzOffset: parseTzOffset,
     tzOffsetForWall: tzOffsetForWall,
     zonedToUtc: zonedToUtc
   }

--- a/Model.js
+++ b/Model.js
@@ -151,10 +151,150 @@ function weekdayOfKey(key) {
   return new Date(Date.UTC(p.y, p.mo - 1, p.d)).getUTCDay()
 }
 
+// --- VTIMEZONE offset table -------------------------------------------------
+// QML's V4 engine has no Intl, so named zones must be resolved from the
+// VTIMEZONE blocks the feed itself ships.
+
+var TZ_TABLE = {}
+
+function parseTzOffset(value) {
+  var m = /^([+-])(\d{2})(\d{2})(\d{2})?$/.exec(String(value || "").trim())
+  if (!m) return null
+  var sign = m[1] === "-" ? -1 : 1
+  var mins = parseInt(m[2], 10) * 60 + parseInt(m[3], 10)
+  var secs = m[4] ? parseInt(m[4], 10) : 0
+  return sign * (mins * 60 + secs) * 1000
+}
+
+// Collect TZID -> observances from raw (already unfolded) ICS lines.
+function registerVTimezones(lines) {
+  var tzid = null
+  var inTz = false
+  var obs = null
+  var list = null
+  for (var i = 0; i < lines.length; i++) {
+    var line = String(lines[i]).trim()
+    if (!line) continue
+    if (line === "BEGIN:VTIMEZONE") { inTz = true; tzid = null; list = []; continue }
+    if (!inTz) continue
+    if (line === "END:VTIMEZONE") {
+      if (tzid && list && list.length) TZ_TABLE[tzid] = list
+      inTz = false; tzid = null; list = null; obs = null
+      continue
+    }
+    if (line === "BEGIN:STANDARD" || line === "BEGIN:DAYLIGHT") {
+      obs = { daylight: line === "BEGIN:DAYLIGHT", from: null, to: null, wall: null, rule: null }
+      continue
+    }
+    if (line === "END:STANDARD" || line === "END:DAYLIGHT") {
+      if (obs && obs.to !== null && obs.wall) {
+        if (obs.from === null) obs.from = obs.to
+        list.push(obs)
+      }
+      obs = null
+      continue
+    }
+    var prop = splitProperty(line)
+    if (!prop) continue
+    if (!obs) {
+      if (prop.name === "TZID") tzid = prop.value.trim()
+      continue
+    }
+    if (prop.name === "TZOFFSETFROM") obs.from = parseTzOffset(prop.value)
+    else if (prop.name === "TZOFFSETTO") obs.to = parseTzOffset(prop.value)
+    else if (prop.name === "DTSTART") {
+      var w = /^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})?)?/.exec(prop.value.trim())
+      if (w) obs.wall = {
+        y: parseInt(w[1], 10), mo: parseInt(w[2], 10), d: parseInt(w[3], 10),
+        h: w[4] ? parseInt(w[4], 10) : 0,
+        mi: w[5] ? parseInt(w[5], 10) : 0,
+        s: w[6] ? parseInt(w[6], 10) : 0
+      }
+    }
+    else if (prop.name === "RRULE") {
+      var r = { month: 0, weekday: -1, ord: 0, monthday: 0 }
+      var segs = prop.value.split(";")
+      for (var k = 0; k < segs.length; k++) {
+        var kv = segs[k].split("=")
+        var key = String(kv[0] || "").toUpperCase()
+        var val = String(kv[1] || "").trim()
+        if (key === "BYMONTH") r.month = parseInt(val, 10) || 0
+        else if (key === "BYMONTHDAY") r.monthday = parseInt(val, 10) || 0
+        else if (key === "BYDAY") {
+          var bd = /^(-?\d+)?(SU|MO|TU|WE|TH|FR|SA)$/.exec(val.split(",")[0].trim())
+          if (bd) {
+            r.ord = bd[1] ? parseInt(bd[1], 10) : 1
+            r.weekday = WEEKDAY[bd[2]]
+          }
+        }
+      }
+      if (r.month) obs.rule = r
+    }
+  }
+}
+
+function nthWeekdayOfMonth(y, mo, weekday, ord) {
+  var dim = daysInMonthUTC(y, mo)
+  if (ord > 0) {
+    var firstDow = new Date(Date.UTC(y, mo - 1, 1)).getUTCDay()
+    var day = 1 + ((weekday - firstDow + 7) % 7) + (ord - 1) * 7
+    return day <= dim ? day : 0
+  }
+  if (ord < 0) {
+    var lastDow = new Date(Date.UTC(y, mo - 1, dim)).getUTCDay()
+    var day2 = dim - ((lastDow - weekday + 7) % 7) + (ord + 1) * 7
+    return day2 >= 1 ? day2 : 0
+  }
+  return 0
+}
+
+// Transition instants for a zone, expressed in that zone's wall clock (the
+// space RFC 5545 observance DTSTARTs live in), for the years around `year`.
+function zoneTransitions(list, year) {
+  var out = []
+  for (var i = 0; i < list.length; i++) {
+    var obs = list[i]
+    if (!obs.rule) {
+      out.push({ wallMs: Date.UTC(obs.wall.y, obs.wall.mo - 1, obs.wall.d, obs.wall.h, obs.wall.mi, obs.wall.s), from: obs.from, to: obs.to })
+      continue
+    }
+    for (var y = year - 1; y <= year + 1; y++) {
+      if (y < obs.wall.y) continue
+      var day = obs.rule.monthday
+        ? Math.min(obs.rule.monthday, daysInMonthUTC(y, obs.rule.month))
+        : nthWeekdayOfMonth(y, obs.rule.month, obs.rule.weekday, obs.rule.ord)
+      if (!day) continue
+      out.push({ wallMs: Date.UTC(y, obs.rule.month - 1, day, obs.wall.h, obs.wall.mi, obs.wall.s), from: obs.from, to: obs.to })
+    }
+  }
+  out.sort(function (a, b) { return a.wallMs - b.wallMs })
+  return out
+}
+
+// Offset in ms that applies to the given wall-clock time in `tzid`,
+// or null when the zone is unknown.
+function tzOffsetForWall(tzid, y, mo, d, h, mi, s) {
+  var list = TZ_TABLE[tzid]
+  if (!list || !list.length) return null
+  var wallMs = Date.UTC(y, mo - 1, d, h, mi, s)
+  var trans = zoneTransitions(list, y)
+  if (!trans.length) return null
+  var off = trans[0].from
+  for (var i = 0; i < trans.length; i++) {
+    if (wallMs >= trans[i].wallMs) off = trans[i].to
+    else break
+  }
+  return off === null ? null : off
+}
+
 // Convert a "local" wall-clock { y, mo, d, h, mi, s } to a UTC Date.
-// TZID: try Intl-aware conversion, fall back to naive local handling.
+// TZID resolution order: VTIMEZONE table, then Intl if the engine has it,
+// then naive local handling as a last resort.
 function zonedToUtc(tzid, y, mo, d, h, mi, s) {
+  var tableOffset = tzOffsetForWall(tzid, y, mo, d, h, mi, s)
+  if (tableOffset !== null) return new Date(Date.UTC(y, mo - 1, d, h, mi, s) - tableOffset)
   try {
+    if (typeof Intl === "undefined") throw new Error("no Intl")
     var guess = new Date(Date.UTC(y, mo - 1, d, h, mi, s))
     var formatter = new Intl.DateTimeFormat("en-US", {
       timeZone: tzid,
@@ -490,6 +630,7 @@ function parseIcs(raw, options) {
   var fromKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
 
   var lines = unfoldIcs(raw)
+  registerVTimezones(lines)
   var blocks = []
   var current = null
   for (var i = 0; i < lines.length; i++) {
@@ -814,6 +955,9 @@ if (typeof module !== "undefined" && module.exports) {
     upcomingToday: upcomingToday,
     eventCalendarUrl: eventCalendarUrl,
     hm: hm,
-    timeRange: timeRange
+    timeRange: timeRange,
+    registerVTimezones: registerVTimezones,
+    tzOffsetForWall: tzOffsetForWall,
+    zonedToUtc: zonedToUtc
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "next-event",
+  "version": "1.0.0",
+  "private": true,
+  "description": "omarchy bar widget showing the next calendar event",
+  "scripts": {
+    "test": "node --test \"test/*.test.js\""
+  }
+}

--- a/test/timezones.test.js
+++ b/test/timezones.test.js
@@ -1,0 +1,213 @@
+"use strict"
+
+const test = require("node:test")
+const assert = require("node:assert")
+const M = require("../Model.js")
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+function block(component, body) {
+  return ["BEGIN:" + component].concat(body).concat(["END:" + component])
+}
+
+const NEW_YORK = block("VTIMEZONE", [
+  "TZID:America/New_York",
+  "BEGIN:DAYLIGHT",
+  "TZOFFSETFROM:-0500",
+  "TZOFFSETTO:-0400",
+  "DTSTART:20070311T020000",
+  "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU",
+  "END:DAYLIGHT",
+  "BEGIN:STANDARD",
+  "TZOFFSETFROM:-0400",
+  "TZOFFSETTO:-0500",
+  "DTSTART:20071104T020000",
+  "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU",
+  "END:STANDARD",
+])
+
+const LONDON = block("VTIMEZONE", [
+  "TZID:Europe/London",
+  "BEGIN:DAYLIGHT",
+  "TZOFFSETFROM:+0000",
+  "TZOFFSETTO:+0100",
+  "DTSTART:19810329T010000",
+  "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU",
+  "END:DAYLIGHT",
+  "BEGIN:STANDARD",
+  "TZOFFSETFROM:+0100",
+  "TZOFFSETTO:+0000",
+  "DTSTART:19961027T020000",
+  "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU",
+  "END:STANDARD",
+])
+
+const KOLKATA = block("VTIMEZONE", [
+  "TZID:Asia/Kolkata",
+  "BEGIN:STANDARD",
+  "TZOFFSETFROM:+0530",
+  "TZOFFSETTO:+0530",
+  "DTSTART:19700101T000000",
+  "END:STANDARD",
+])
+
+const IRAN = block("VTIMEZONE", [
+  "TZID:Test/Iran",
+  "BEGIN:STANDARD",
+  "TZOFFSETFROM:+0430",
+  "TZOFFSETTO:+0330",
+  "DTSTART:19700101T000000",
+  "RRULE:FREQ=YEARLY;BYMONTH=9;BYMONTHDAY=22",
+  "END:STANDARD",
+  "BEGIN:DAYLIGHT",
+  "TZOFFSETFROM:+0330",
+  "TZOFFSETTO:+0430",
+  "DTSTART:19700101T000000",
+  "RRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=22",
+  "END:DAYLIGHT",
+])
+
+function register(...tzBlocks) {
+  M.registerVTimezones(Array.prototype.concat.apply([], tzBlocks))
+}
+
+test("parseTzOffset handles signed HHMM and HHMMSS", () => {
+  assert.strictEqual(M.parseTzOffset("+0530"), 5.5 * 60 * 60 * 1000)
+  assert.strictEqual(M.parseTzOffset("-0400"), -4 * 60 * 60 * 1000)
+  assert.strictEqual(M.parseTzOffset("+004530"), 45 * 60 * 1000 + 30 * 1000)
+  assert.strictEqual(M.parseTzOffset("garbage"), null)
+})
+
+test("fixed-offset zone resolves a constant offset", () => {
+  register(KOLKATA)
+  for (const [y, mo, d] of [[2024, 1, 1], [2026, 8, 18], [2028, 12, 31]]) {
+    assert.strictEqual(
+      M.tzOffsetForWall("Asia/Kolkata", y, mo, d, 12, 0, 0),
+      5.5 * 60 * 60 * 1000
+    )
+  }
+})
+
+test("DST zone resolves different offsets across seasons", () => {
+  register(NEW_YORK)
+  assert.strictEqual(M.tzOffsetForWall("America/New_York", 2026, 1, 15, 12, 0, 0), -5 * 60 * 60 * 1000)
+  assert.strictEqual(M.tzOffsetForWall("America/New_York", 2026, 8, 18, 12, 0, 0), -4 * 60 * 60 * 1000)
+})
+
+test("negative-ordinal BYDAY rule (last Sunday) resolves correctly", () => {
+  register(LONDON)
+  assert.strictEqual(M.tzOffsetForWall("Europe/London", 2026, 1, 15, 12, 0, 0), 0)
+  assert.strictEqual(M.tzOffsetForWall("Europe/London", 2026, 8, 18, 12, 0, 0), 60 * 60 * 1000)
+})
+
+test("BYMONTHDAY rule resolves on the correct calendar date", () => {
+  register(IRAN)
+  assert.strictEqual(M.tzOffsetForWall("Test/Iran", 2026, 3, 21, 12, 0, 0), 3.5 * 60 * 60 * 1000)
+  assert.strictEqual(M.tzOffsetForWall("Test/Iran", 2026, 3, 22, 12, 0, 0), 4.5 * 60 * 60 * 1000)
+  assert.strictEqual(M.tzOffsetForWall("Test/Iran", 2026, 9, 22, 12, 0, 0), 3.5 * 60 * 60 * 1000)
+  assert.strictEqual(M.tzOffsetForWall("Test/Iran", 2026, 9, 23, 12, 0, 0), 3.5 * 60 * 60 * 1000)
+})
+
+test("PR scenario: NY 13:00 converts to 17:00 UTC (viewer in Anchorage sees 09:00)", () => {
+  register(NEW_YORK)
+  const utc = M.zonedToUtc("America/New_York", 2026, 8, 18, 13, 0, 0)
+  assert.strictEqual(utc.toISOString(), "2026-08-18T17:00:00.000Z")
+  // Format the resulting instant back in the viewer's zone (Anchorage).
+  const anchor = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Anchorage",
+    hour12: false,
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit",
+  }).formatToParts(utc)
+  const W = Object.fromEntries(anchor.map((p) => [p.type, p.value]))
+  assert.strictEqual(W.hour % 24, 9)
+})
+
+test("round-trips wall times against the system tz database", () => {
+  register(NEW_YORK, LONDON, KOLKATA)
+  const zones = ["America/New_York", "Europe/London", "Asia/Kolkata"]
+  const overlapping = new Set()
+  for (const z of zones) {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: z,
+      hour12: false,
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+    })
+    for (let y = 2024; y <= 2028; y++) {
+      for (let mo = 1; mo <= 12; mo++) {
+        for (const d of [1, 7, 14, 21, 28]) {
+          for (const h of [0, 3, 6, 9, 12, 15, 18, 21]) {
+            const t0 = Date.UTC(y, mo - 1, d, h)
+            const W = Object.fromEntries(fmt.formatToParts(new Date(t0)).map((p) => [p.type, p.value]))
+            const wallMs = Date.UTC(+W.year, +W.month - 1, +W.day, +W.hour % 24, +W.minute, +W.second)
+            const got = M.zonedToUtc(z, +W.year, +W.month, +W.day, +W.hour % 24, +W.minute, +W.second)
+            if (Math.abs(got.getTime() - t0) > 1000) {
+              // Only wall times inside a fall-back overlap are ambiguous;
+              // they exist twice and either reading is valid.
+              overlapping.add(z + " " + W.year + "-" + W.month + "-" + W.day + " " + W.hour + ":00")
+            }
+          }
+        }
+      }
+    }
+  }
+  assert.ok(overlapping.size < 20, "unexpected round-trip mismatches: " + [...overlapping].join(", "))
+})
+
+test("unknown zone falls back to the previous naive local handling", () => {
+  register(NEW_YORK)
+  const got = M.zonedToUtc("No/Such_Zone", 2026, 8, 18, 13, 0, 0)
+  const expected = new Date(2026, 7, 18, 13, 0, 0)
+  assert.strictEqual(got.getTime(), expected.getTime())
+})
+
+test("works without Intl (QML V4 engine simulation)", () => {
+  register(NEW_YORK)
+  const originalIntl = global.Intl
+  global.Intl = undefined
+  try {
+    const utc = M.zonedToUtc("America/New_York", 2026, 8, 18, 13, 0, 0)
+    assert.strictEqual(utc.toISOString(), "2026-08-18T17:00:00.000Z")
+  } finally {
+    global.Intl = originalIntl
+  }
+})
+
+test("resets the table per parse so a dropped zone does not resolve against stale data", () => {
+  register(NEW_YORK)
+  assert.notStrictEqual(M.tzOffsetForWall("America/New_York", 2026, 8, 18, 13, 0, 0), null)
+
+  // Second parse ships a different feed without America/New_York.
+  register(KOLKATA)
+  assert.strictEqual(M.tzOffsetForWall("America/New_York", 2026, 8, 18, 13, 0, 0), null)
+  assert.notStrictEqual(M.tzOffsetForWall("Asia/Kolkata", 2026, 8, 18, 13, 0, 0), null)
+})
+
+test("parseIcs resolves TZID events through the table end to end", () => {
+  const ics = NEW_YORK.concat([
+    "BEGIN:VEVENT",
+    "UID:team-sync-2026",
+    "DTSTAMP:20260818T000000Z",
+    "DTSTART;TZID=America/New_York:20260818T130000",
+    "DTEND;TZID=America/New_York:20260818T140000",
+    "SUMMARY:Team sync",
+    "END:VEVENT",
+  ])
+  const parsed = M.parseIcs(ics.join("\n"), { now: new Date(Date.UTC(2026, 7, 18, 0, 0)) })
+  const ev = parsed[0]
+  assert.ok(ev)
+  assert.strictEqual(ev.start.toISOString(), "2026-08-18T17:00:00.000Z")
+  assert.strictEqual(ev.title, "Team sync")
+})
+
+test("DST transition boundary: weekly series keeps its wall time across the spring-forward", () => {
+  register(NEW_YORK)
+  // 2026-03-08 is the US spring-forward. A weekly 09:00 EST series starts
+  // before it and must keep starting at 09:00 local after the transition.
+  const start = M.zonedToUtc("America/New_York", 2026, 3, 1, 9, 0, 0)
+  const after = M.zonedToUtc("America/New_York", 2026, 3, 15, 9, 0, 0)
+  assert.strictEqual(start.toISOString(), "2026-03-01T14:00:00.000Z")
+  assert.strictEqual(after.toISOString(), "2026-03-15T13:00:00.000Z")
+  assert.strictEqual(after.getTime() - start.getTime(), 14 * DAY_MS - 60 * 60 * 1000) // 14 days, minus the spring-forward hour
+})


### PR DESCRIPTION
- **fix: resolve TZID events via VTIMEZONE table**
- **refactor: reset VTIMEZONE table per parse and name offset constants**
- **test: add VTIMEZONE offset table tests**
- **docs: add AGENTS.md with architecture, test, and workflow notes**
