### PR TITLE
docs: document release and marketplace verification process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,13 @@ lets you click to join Google Meet. NOT a Node app — the runtime is QML.
 
 - Contributions follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...) and a strictly linear history (rebase, no merge commits). See README's Contributing section.
 - Widget settings are configured via `omarchy bar set tobiasz-p.next-event <key> <value>`; defaults live in the README table (e.g. `icsUrl`, `refreshMinutes`, `showDaysAhead`).
+
+## Releasing
+
+- Merge all PRs **before** tagging. The marketplace verifies exact commit snapshots, which are immutable once published — a feature missing from a tagged release can only be fixed by cutting a new version, never by moving the tag.
+- Semver from Conventional Commits: `fix:` → patch, `feat:` → minor, breaking → major.
+- Bump `version` in `manifest.json`, commit as `chore: bump version to X.Y.Z`, then tag without the `v` prefix and push both:
+  `git tag -a X.Y.Z -m "X.Y.Z" && git push origin main X.Y.Z`
+- Create the GitHub release with notes covering changes since the previous tag:
+  `gh release create X.Y.Z --title "X.Y.Z" --notes "..."`
+- Ask for marketplace verification with a `[Verify]` issue on HANCORE-linux/omarchy-plugin-marketplace (verify-plugin.yml template): action "Verify and publish a newer upstream commit", plugin ID `tobiasz-p.next-event`, repo URL, and the full 40-char SHA of the release commit. A bot validates, runs a security baseline, then a maintainer applies `approved-and-verified` and publishes that exact snapshot.


### PR DESCRIPTION
Adds a `Releasing` section to AGENTS.md covering:

- merge PRs before tagging (marketplace snapshots are immutable)
- semver mapping from Conventional Commits
- version bump, tag (no `v` prefix), and GitHub release steps
- filing the `[Verify]` issue on HANCORE-linux/omarchy-plugin-marketplace for exact-commit verification