### PR TITLE
fix: correct video-link detection for Zoom, Teams, Webex and GoTo

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -647,7 +647,13 @@ function parseEventBlock(block) {
     else if (name === "RRULE") ev.rrule = parseRRule(value)
     else if (name === "LOCATION") ev.location = unescapeIcs(value)
     else if (name === "DESCRIPTION") ev.description = unescapeIcs(value)
-    else if (name === "X-GOOGLE-CONFERENCE") ev.xConference = value.trim()
+    // Vendor properties carrying a join link directly. Outlook/Exchange emits the
+    // Teams one, which beats scraping it back out of the description.
+    else if (name === "X-GOOGLE-CONFERENCE" || name === "X-MICROSOFT-SKYPETEAMSMEETINGURL")
+      ev.xConference = (ev.xConference ? ev.xConference + " " : "") + value.trim()
+    // RFC 7986 CONFERENCE — where Outlook, Nextcloud, Proton and other non-Google
+    // feeds put the join link. An event may carry several (video, phone).
+    else if (name === "CONFERENCE") ev.conference = (ev.conference ? ev.conference + " " : "") + value.trim()
     else if (name === "EXDATE") {
       var parts = value.split(",")
       for (var j = 0; j < parts.length; j++) {
@@ -659,7 +665,7 @@ function parseEventBlock(block) {
 
   if (!ev.uid || !ev.start) return null
 
-  ev.meetUrl = findMeetUrl((ev.location || "") + " " + (ev.description || "") + " " + (ev.xConference || ""))
+  ev.meetUrl = findMeetUrl((ev.location || "") + " " + (ev.description || "") + " " + (ev.xConference || "") + " " + (ev.conference || ""))
   if (ev.end && ev.end.getTime() > ev.start.getTime()) {
     ev.durationMs = ev.end.getTime() - ev.start.getTime()
   } else {

--- a/Model.js
+++ b/Model.js
@@ -562,17 +562,32 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
 
 var VIDEO_PROVIDERS = [
   { re: /https:\/\/meet\.google\.com\/[a-z0-9][a-z0-9-]*/, label: "Meet" },
-  { re: /https?:\/\/(?:[\w-]+\.)?zoom\.us\/(?:j|w)\/\d+(?:\?[^\s]*)*/, label: "Video" },
-  { re: /https?:\/\/(?:teams\.microsoft\.com|teams\.live\.com)\/(?:l\/meetup-join|meet|dl\/launcher)\/[^\s]*/, label: "Video" },
-  { re: /https?:\/\/(?:[\w-]+\.)?webex\.com\/(?:meet|j\.php)[^\s]*/, label: "Video" },
-  { re: /https?:\/\/(?:[\w-]+\.)?gotomeeting\.com\/join\/\d+/, label: "Video" },
+  // Vanity subdomains (us02web., <company>.), /j/ meetings, /w/ and /s/ webinars,
+  // /my/ personal rooms, on both the commercial domain and Zoom for Government.
+  { re: /https?:\/\/(?:[\w-]+\.)*(?:zoom\.us|zoomgov\.com)\/(?:j|w|s|my)\/[^\s"'<>]+/, label: "Video" },
+  // Commercial, personal (teams.live.com) and government (GCC High / DoD, on
+  // teams.microsoft.us) tenants. Paths stay restricted: an Outlook invite body
+  // also links teams.microsoft.com/meetingOptions/… below the join link, so a
+  // domain-only match would join the settings page.
+  { re: /https?:\/\/(?:teams\.microsoft\.com|teams\.live\.com|(?:[\w-]+\.)?teams\.microsoft\.us)\/(?:l\/meetup-join|l\/meeting|meet|dl\/launcher)\/[^\s"'<>]+/, label: "Video" },
+  // Personal rooms (/meet/, /join/) and the hosted-site form,
+  // <company>.webex.com/<site>/j.php?MTID=… — the site segment sits before j.php.
+  { re: /https?:\/\/(?:[\w-]+\.)*webex\.com\/(?:meet\/|join\/|[^\s"'<>]*j\.php\?)[^\s"'<>]+/, label: "Video" },
+  // meet.goto.com and gotomeet.me host nothing but meetings, so any path will do.
+  // gotomeeting.com also serves marketing pages, hence /join/.
+  { re: /https?:\/\/(?:(?:meet\.goto\.com|(?:www\.)?gotomeet\.me)\/[^\s"'<>]+|(?:[\w-]+\.)*gotomeeting\.com\/join\/[^\s"'<>]+)/, label: "Video" },
 ]
+
+// Sentence punctuation trailing a URL belongs to the prose, not the link.
+function trimUrlPunctuation(url) {
+  return String(url || "").replace(/[.,;:!?)\]]+$/, "")
+}
 
 function findMeetUrl(text) {
   var s = String(text || "")
   for (var i = 0; i < VIDEO_PROVIDERS.length; i++) {
     var m = VIDEO_PROVIDERS[i].re.exec(s)
-    if (m) return m[0]
+    if (m) return trimUrlPunctuation(m[0])
   }
   return null
 }


### PR DESCRIPTION
Follow-up to #8, which added the multi-provider table I offered in #1 — thanks for
picking that up. Running it against my own feeds turned up a handful of link shapes
it misses, and one case where the match succeeds but produces a URL that cannot be
joined. Two commits, `Model.js` only, +28/−7.

### The part that matters most: captured-but-broken URLs

The provider patterns terminate on whitespace (`[^\s]*`), so a link embedded in real
invite markup is captured with the surrounding punctuation still attached. The result
isn't a missed meeting — it's a **Join Meeting button that opens a malformed URL**:

| feed | captured today |
|---|---|
| Google Calendar wraps links in `<a href="…">` | `https://us02web.zoom.us/j/8551234?pwd=xY9">Join` |
| Outlook wraps the Teams join link in bare angle brackets | `https://teams.microsoft.com/l/meetup-join/…/0>` |

Outlook's `Click here to join the meeting<https://…>` is the standard shape of a Teams
invite, not an edge case, so this affects most Teams users rather than a few.

This terminates matches on quotes and angle brackets as well as whitespace, and strips
trailing sentence punctuation — a URL at the end of a sentence or inside parentheses
otherwise absorbs the `.` or `)`.

### Link shapes the patterns don't reach yet

| provider | added |
|---|---|
| **Zoom** | `zoomgov.com` (Zoom for Government); `/s/` webinars and `/my/` personal rooms; meeting IDs that aren't purely numeric; more than one subdomain label |
| **Teams** | government tenants on `*.teams.microsoft.us` (GCC High / DoD), and the `l/meeting` path |
| **Webex** | the hosted-site form `<company>.webex.com/<site>/j.php?MTID=…`, whose site segment sits between the host and `j.php` — the current pattern anchors `j.php` directly to the host, so the most common Webex link never matches. Plus `/join/` personal rooms |
| **GoTo** | `meet.goto.com` and `gotomeet.me`, the forms GoTo issues today |

Paths stay restricted rather than opening up to the host, and that's load-bearing. An
Outlook Teams invite also links `meetingOptions` on the join host; a Teams/Webex interop
body links `www.webex.com/msteams`. A host-only match joins the settings page or the
interop page instead of the meeting.

Google Meet detection is untouched, and Meet keeps its position at the head of the
table, so an event carrying links for two providers resolves exactly as it does today.

### Second commit: the ICS properties non-Google feeds use

Link detection reads `LOCATION`, `DESCRIPTION` and `X-GOOGLE-CONFERENCE` — all Google
conventions. The README advertises any `.ics` feed (Outlook, iCloud, Nextcloud, Proton,
CalDAV), and those feeds put the join link in the RFC 7986 `CONFERENCE` property, which
isn't parsed. Outlook/Exchange also emits `X-MICROSOFT-SKYPETEAMSMEETINGURL` directly.

So an event from a non-Google calendar gets no `meetUrl` even when the feed states the
join link outright — and since `showOnlyWithVideoLink` defaults to true, the event is
dropped from the bar widget entirely. **This affects Google Meet links on those feeds
too**, not just the other providers.

An event may carry several `CONFERENCE` values (video, phone), so they accumulate rather
than overwrite and the provider table picks the video one; a `FEATURE=PHONE` `tel:` URI
matches no pattern and is ignored.

Happy to split this second commit out if you'd rather take the detection fix on its own —
they're independent and touch different lines.

### Scope

`Model.js` only. `Panel.qml`, `BarWidget.qml`, `README.md` and `manifest.json` are
untouched, and the `VIDEO_PROVIDERS` shape, the `findMeetUrl` / `meetLabel` names, the
`Meet` / `Video` label scheme and the `dl/launcher` path from #8 are all preserved.

### Testing

Verified against real Outlook, Webex and GoTo invite bodies plus synthetic feeds for each
provider. I have a 39-case suite covering all of this, which I've kept out of this PR to
keep the diff reviewable — it's in a follow-up so you can take it or leave it separately.
Against `main` today it's 26/39; with this change, 39/39.

Also happy to add a `README` line for `zoomgov.com` / gov tenants if you want the
provider list spelled out, but I've left docs alone here.

Refs #1
