### PR TITLE
test: cover meeting-link detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,24 @@ lets you click to join Google Meet. NOT a Node app — the runtime is QML.
 - TZID table (`TZ_TABLE`) is reset at the start of every `parseIcs`/`registerVTimezones`. A feed that drops a zone must not resolve against stale data; don't make the table accumulate across parses.
 - Keep Model.js dependency-free (pure). The QML sandbox cannot load npm packages; runtime deps are not possible.
 
+## Tests
+
+```sh
+npm test          # node --test "test/*.test.js"
+```
+
+One suite: `test/meeting-links.test.js`. It covers the `VIDEO_PROVIDERS` table,
+`findMeetUrl`, `meetLabel`, and every ICS property a join link can arrive in
+(`LOCATION`, `DESCRIPTION`, `CONFERENCE`, `X-GOOGLE-CONFERENCE`,
+`X-MICROSOFT-SKYPETEAMSMEETINGURL`). Several fixtures are modelled on real
+Outlook, Webex and GoTo invite bodies with identifiers replaced — the decoy
+links they carry (`meetingOptions`, dial-in helpers, Teams/Webex interop) are
+why the provider patterns restrict paths instead of matching on host alone.
+Add new meeting-link cases to this file using the existing `feed()`/`parseOne()`
+helpers. No lint, formatter, or typecheck is configured.
+
+Tests cover Model.js only; the QML layer has no automated coverage.
+
 ## Workflow conventions
 
 - Contributions follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...) and a strictly linear history (rebase, no merge commits). See README's Contributing section.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,26 @@ External contributors need to fork the repository first (as only maintainers hav
    ```
 6. **Open a Pull Request**: Go to the GitHub repository and submit a PR from your branch against `upstream/main` with a clear description of the changes.
 
+### Running tests
+
+`Model.js` is pure JavaScript with no Qt or Quickshell imports, so it runs under
+Node directly. The suite uses Node's built-in test runner and has no
+dependencies — there is nothing to install:
+
+```sh
+npm test                                  # every suite in test/
+node --test test/meeting-links.test.js    # a single suite while iterating
+```
+
+Tests cover `Model.js` only. The QML layer (`BarWidget.qml`, `Panel.qml`) has no
+automated coverage, so check UI changes by hand in your Omarchy environment. No
+lint, formatter, or typecheck is configured.
+
+When adding to `Model.js`, keep every function top-level and leave the
+`module.exports` guard at the bottom of the file: QML does
+`import "Model.js" as Model` while Node does `require("./Model.js")`, and that
+guard is what keeps both working.
+
 ### Commit Guidelines
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/). Write concise, descriptive commit messages in the imperative mood:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "next-event",
+  "private": true,
+  "description": "omarchy bar widget showing the next calendar event",
+  "scripts": {
+    "test": "node --test \"test/*.test.js\""
+  }
+}

--- a/test/meeting-links.test.js
+++ b/test/meeting-links.test.js
@@ -1,0 +1,345 @@
+"use strict"
+
+// Meeting-link detection: the VIDEO_PROVIDERS table, findMeetUrl(), meetLabel(),
+// and the ICS properties a join link can arrive in.
+//
+// Several fixtures are modelled on real Outlook, Webex and GoTo invite bodies
+// with identifiers replaced — the decoy links they carry (meetingOptions, dial-in
+// helpers, Teams/Webex interop) are the reason the provider patterns restrict
+// paths instead of matching on host alone.
+
+const { describe, it } = require("node:test")
+const assert = require("node:assert")
+const M = require("../Model.js")
+
+const NOW = new Date("2026-08-17T09:00:00Z")
+
+let uid = 0
+
+// Build a single-VEVENT feed from raw property lines.
+function feed(lines) {
+  uid++
+  return [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "BEGIN:VEVENT",
+    "UID:test-" + uid,
+    "DTSTART:20260817T140000Z",
+    "DTEND:20260817T150000Z",
+    "SUMMARY:Test Event",
+    ...lines,
+    "END:VEVENT",
+    "END:VCALENDAR"
+  ].join("\r\n")
+}
+
+function parseOne(lines) {
+  const events = M.parseIcs(feed(lines), { now: NOW, lookaheadDays: 7 })
+  assert.strictEqual(events.length, 1, "expected exactly one parsed event")
+  return events[0]
+}
+
+describe("Zoom link detection", () => {
+  it("finds a Zoom URL in LOCATION", () => {
+    const ev = parseOne(["LOCATION:https://us02web.zoom.us/j/85512345678"])
+    assert.strictEqual(ev.meetUrl, "https://us02web.zoom.us/j/85512345678")
+  })
+
+  it("preserves the ?pwd= query", () => {
+    const ev = parseOne(["DESCRIPTION:Join Zoom Meeting\\nhttps://zoom.us/j/1234567890?pwd=aBcDeFgH"])
+    assert.strictEqual(ev.meetUrl, "https://zoom.us/j/1234567890?pwd=aBcDeFgH")
+  })
+
+  it("accepts vanity subdomains", () => {
+    const ev = parseOne(["LOCATION:https://acmecorp.zoom.us/j/99988877766"])
+    assert.strictEqual(ev.meetUrl, "https://acmecorp.zoom.us/j/99988877766")
+  })
+
+  it("accepts zoomgov.com (Zoom for Government)", () => {
+    const ev = parseOne(["LOCATION:https://www.zoomgov.com/j/1616161616"])
+    assert.strictEqual(ev.meetUrl, "https://www.zoomgov.com/j/1616161616")
+  })
+
+  it("accepts personal rooms (/my/)", () => {
+    const ev = parseOne(["LOCATION:https://zoom.us/my/jane.doe"])
+    assert.strictEqual(ev.meetUrl, "https://zoom.us/my/jane.doe")
+  })
+
+  it("accepts webinars (/w/)", () => {
+    const ev = parseOne(["LOCATION:https://zoom.us/w/84512345678"])
+    assert.strictEqual(ev.meetUrl, "https://zoom.us/w/84512345678")
+  })
+})
+
+describe("Teams link detection", () => {
+  // A real Outlook invite body: the join link is wrapped in angle brackets, and
+  // a meetingOptions link to the same host sits a few lines below it.
+  const OUTLOOK_BODY =
+    "DESCRIPTION:____________________________________\\n" +
+    "Microsoft Teams meeting\\n" +
+    "Click here to join the meeting" +
+    "<https://teams.microsoft.com/l/meetup-join/19%3ameeting_NmYxZTgz%40thread.v2/0" +
+    "?context=%7b%22Tid%22%3a%22abc%22%2c%22Oid%22%3a%22def%22%7d>\\n" +
+    "Meeting ID: 123 456 789 012\\nPasscode: aBcDeF\\n" +
+    "Learn More<https://aka.ms/JoinTeamsMeeting> | " +
+    "Meeting options<https://teams.microsoft.com/meetingOptions/?organizerId=abc>\\n"
+
+  it("extracts the join link from an Outlook invite body", () => {
+    const ev = parseOne([OUTLOOK_BODY])
+    assert.strictEqual(ev.meetUrl,
+      "https://teams.microsoft.com/l/meetup-join/19%3ameeting_NmYxZTgz%40thread.v2/0" +
+      "?context=%7b%22Tid%22%3a%22abc%22%2c%22Oid%22%3a%22def%22%7d")
+  })
+
+  // The path restriction earns its keep here: meetingOptions is on the same
+  // host, so a domain-only pattern would happily "join" the settings page.
+  it("does not mistake a meetingOptions link for a join link", () => {
+    const ev = parseOne([
+      "DESCRIPTION:Meeting options<https://teams.microsoft.com/meetingOptions/?organizerId=abc>"
+    ])
+    assert.strictEqual(ev.meetUrl, null)
+  })
+
+  // Modelled on a real corporate invite (identifiers replaced). The modern
+  // short link is the one a human is told to click; the older l/meetup-join
+  // form is demoted to "System reference" below it. Four decoys share the body:
+  // a meetingOptions page on the same host, two dialin.teams.cloud.microsoft
+  // links, an aka.ms redirect, and — the nasty one — a www.webex.com interop
+  // link, which a host-only Webex pattern would happily treat as a meeting.
+  const MODERN_INVITE =
+    "DESCRIPTION:____________________________________\\n" +
+    "Microsoft Teams meeting\\n" +
+    "Join: https://teams.microsoft.com/meet/100000000000000?p=AbCdEfGhIjKlMnOpQr\\n" +
+    "Meeting ID: 100 000 000 000 000\\nPasscode: a1b2c3d4\\n" +
+    "________________________________\\n" +
+    "Need help?<https://aka.ms/JoinTeamsMeeting?omkt=en-US> | " +
+    "System reference<https://teams.microsoft.com/l/meetup-join/19%3ameeting_" +
+    "AAAABBBBCCCCDDDD%40thread.v2/0?context=%7b%22Tid%22%3a%2200000000-0000-0000-0000-000000000000%22%7d>\\n" +
+    "Dial in by phone\\n+1 555-000-0000\\,\\,000000000#<tel:+15550000000\\,\\,000000000> United States\\n" +
+    "Find a local number<https://dialin.teams.cloud.microsoft/00000000-0000-0000-0000-000000000000?id=000000000>\\n" +
+    "Join on a video conferencing device\\nTenant key: example@m.webex.com\\n" +
+    "More info<https://www.webex.com/msteams?confid=0000000000&tenantkey=example&domain=m.webex.com>\\n" +
+    "For organizers: Meeting options<https://teams.microsoft.com/meetingOptions/?organizerId=0000&tenantId=0000> | " +
+    "Reset dial-in PIN<https://dialin.teams.cloud.microsoft/usp/pstnconferencing>\\n"
+
+  it("picks the modern short join link out of a full invite body", () => {
+    const ev = parseOne([MODERN_INVITE])
+    assert.strictEqual(ev.meetUrl,
+      "https://teams.microsoft.com/meet/100000000000000?p=AbCdEfGhIjKlMnOpQr")
+  })
+
+  it("ignores the Webex interop link inside a Teams invite", () => {
+    // On its own, with no Teams link to outrank it, the interop page must still
+    // not register as a Webex meeting.
+    const ev = parseOne([
+      "DESCRIPTION:More info<https://www.webex.com/msteams?confid=0000000000&tenantkey=example>"
+    ])
+    assert.strictEqual(ev.meetUrl, null)
+  })
+
+  it("ignores dial-in helper links on teams.cloud.microsoft", () => {
+    const ev = parseOne([
+      "DESCRIPTION:Find a local number<https://dialin.teams.cloud.microsoft/0000?id=1>"
+    ])
+    assert.strictEqual(ev.meetUrl, null)
+  })
+
+  it("accepts teams.live.com personal meetings", () => {
+    const ev = parseOne(["LOCATION:https://teams.live.com/meet/9312345678901"])
+    assert.strictEqual(ev.meetUrl, "https://teams.live.com/meet/9312345678901")
+  })
+
+  it("accepts government tenants on teams.microsoft.us", () => {
+    const ev = parseOne(["LOCATION:https://dod.teams.microsoft.us/l/meetup-join/19%3ameeting_abc%40thread.v2/0"])
+    assert.strictEqual(ev.meetUrl, "https://dod.teams.microsoft.us/l/meetup-join/19%3ameeting_abc%40thread.v2/0")
+  })
+
+  it("accepts a dl/launcher link", () => {
+    const ev = parseOne(["LOCATION:https://teams.microsoft.com/dl/launcher/abc123?type=meetup-join"])
+    assert.strictEqual(ev.meetUrl, "https://teams.microsoft.com/dl/launcher/abc123?type=meetup-join")
+  })
+
+  it("reads the X-MICROSOFT-SKYPETEAMSMEETINGURL property", () => {
+    const ev = parseOne([
+      "X-MICROSOFT-SKYPETEAMSMEETINGURL:https://teams.microsoft.com/l/meetup-join/19%3ameeting_xyz%40thread.v2/0"
+    ])
+    assert.strictEqual(ev.meetUrl,
+      "https://teams.microsoft.com/l/meetup-join/19%3ameeting_xyz%40thread.v2/0")
+  })
+})
+
+describe("Webex link detection", () => {
+  it("accepts a hosted-site j.php link", () => {
+    const ev = parseOne(["LOCATION:https://acme.webex.com/acme/j.php?MTID=m0123456789abcdef"])
+    assert.strictEqual(ev.meetUrl, "https://acme.webex.com/acme/j.php?MTID=m0123456789abcdef")
+  })
+
+  it("accepts a personal room", () => {
+    const ev = parseOne(["LOCATION:https://acme.webex.com/meet/jane.doe"])
+    assert.strictEqual(ev.meetUrl, "https://acme.webex.com/meet/jane.doe")
+  })
+
+  it("accepts a /join/ link", () => {
+    const ev = parseOne(["LOCATION:https://acme.webex.com/join/jane.doe"])
+    assert.strictEqual(ev.meetUrl, "https://acme.webex.com/join/jane.doe")
+  })
+
+  it("does not match a bare webex.com marketing link", () => {
+    const ev = parseOne(["DESCRIPTION:See https://www.webex.com/pricing for plans"])
+    assert.strictEqual(ev.meetUrl, null)
+  })
+
+  it("does not match the help site", () => {
+    assert.strictEqual(M.findMeetUrl("https://help.webex.com"), null)
+    assert.strictEqual(M.findMeetUrl("https://help.webex.com/"), null)
+  })
+
+  // Modelled on a real corporate invite (identifiers replaced). The join link
+  // carries a site segment before j.php, and the body also contains a SIP dial
+  // address on the same host and a help.webex.com link — neither is a meeting.
+  it("picks the join link out of a full invite body", () => {
+    const ev = parseOne([
+      "DESCRIPTION:More ways to join:\\n\\nJoin from the meeting link\\n" +
+      "https://example.webex.com/example/j.php?MTID=m00000000000000000000000000000000\\n\\n" +
+      "Join by meeting number\\nMeeting number (access code): 2541 422 4390\\n" +
+      "Meeting password: Xxxxxxxxxxx\\n" +
+      "Join from a video system or application\\nDial 25414224390@example.webex.com\\n" +
+      "Need help? Go to https://help.webex.com"
+    ])
+    assert.strictEqual(ev.meetUrl,
+      "https://example.webex.com/example/j.php?MTID=m00000000000000000000000000000000")
+  })
+})
+
+describe("GoTo link detection", () => {
+  it("accepts a meet.goto.com link", () => {
+    const ev = parseOne([
+      "DESCRIPTION:You can join this meeting from your computer\\, tablet\\, or smartphone.\\n" +
+      "https://meet.goto.com/119227189\\n\\nYou can also dial in using your phone.\\n" +
+      "US: +1 312 757 3121\\nAccess Code: 119-227-189"
+    ])
+    assert.strictEqual(ev.meetUrl, "https://meet.goto.com/119227189")
+  })
+
+  it("accepts the legacy gotomeeting.com/join form", () => {
+    const ev = parseOne(["LOCATION:https://global.gotomeeting.com/join/119227189"])
+    assert.strictEqual(ev.meetUrl, "https://global.gotomeeting.com/join/119227189")
+  })
+
+  it("accepts a gotomeet.me personal room", () => {
+    const ev = parseOne(["LOCATION:https://www.gotomeet.me/example.person"])
+    assert.strictEqual(ev.meetUrl, "https://www.gotomeet.me/example.person")
+  })
+
+  it("does not match a gotomeeting.com marketing page", () => {
+    assert.strictEqual(M.findMeetUrl("https://www.gotomeeting.com/pricing"), null)
+  })
+})
+
+describe("URL boundary handling", () => {
+  it("stops at the quote inside an HTML anchor", () => {
+    const ev = parseOne(['DESCRIPTION:<a href="https://us06web.zoom.us/j/123456?pwd=xyz">Join</a>'])
+    assert.strictEqual(ev.meetUrl, "https://us06web.zoom.us/j/123456?pwd=xyz")
+  })
+
+  it("strips a trailing sentence period", () => {
+    const ev = parseOne(["DESCRIPTION:Please join at https://zoom.us/j/9876543210."])
+    assert.strictEqual(ev.meetUrl, "https://zoom.us/j/9876543210")
+  })
+
+  it("strips a trailing close-paren", () => {
+    const ev = parseOne(["DESCRIPTION:Dial in (https://zoom.us/j/5551112222) or call."])
+    assert.strictEqual(ev.meetUrl, "https://zoom.us/j/5551112222")
+  })
+
+  // RFC 5545 folding: continuation lines begin with a single space. Feeds wrap
+  // at 75 octets, so any Zoom URL carrying a pwd arrives folded.
+  it("reassembles a folded long URL", () => {
+    const ev = parseOne([
+      "DESCRIPTION:Join Zoom Meeting\\nhttps://us02web.zoom.us/j/8551234",
+      " 5678?pwd=VGhpc0lzQVRlc3RQYXNzd29yZA"
+    ])
+    assert.strictEqual(ev.meetUrl,
+      "https://us02web.zoom.us/j/85512345678?pwd=VGhpc0lzQVRlc3RQYXNzd29yZA")
+  })
+
+  it("does not treat a bare domain mention as a link", () => {
+    const ev = parseOne(["LOCATION:Discussion about zoom.us pricing"])
+    assert.strictEqual(ev.meetUrl, null)
+  })
+})
+
+describe("CONFERENCE property (RFC 7986)", () => {
+  it("reads a Zoom link from CONFERENCE", () => {
+    const ev = parseOne(["CONFERENCE;VALUE=URI;FEATURE=VIDEO;LABEL=Join:https://zoom.us/j/5550001111"])
+    assert.strictEqual(ev.meetUrl, "https://zoom.us/j/5550001111")
+  })
+
+  it("reads a Meet link from CONFERENCE", () => {
+    const ev = parseOne(["CONFERENCE;VALUE=URI;FEATURE=VIDEO:https://meet.google.com/abc-defg-hij"])
+    assert.strictEqual(ev.meetUrl, "https://meet.google.com/abc-defg-hij")
+  })
+})
+
+describe("provider priority", () => {
+  it("resolves to Meet when an event carries both", () => {
+    const ev = parseOne([
+      "LOCATION:https://us02web.zoom.us/j/85512345678",
+      "DESCRIPTION:Backup: https://meet.google.com/abc-defg-hij"
+    ])
+    assert.strictEqual(ev.meetUrl, "https://meet.google.com/abc-defg-hij")
+  })
+})
+
+describe("Google Meet regressions", () => {
+  it("still finds a Meet link in DESCRIPTION", () => {
+    const ev = parseOne(["DESCRIPTION:https://meet.google.com/abc-defg-hij"])
+    assert.strictEqual(ev.meetUrl, "https://meet.google.com/abc-defg-hij")
+  })
+
+  it("still finds a Meet link in X-GOOGLE-CONFERENCE", () => {
+    const ev = parseOne(["X-GOOGLE-CONFERENCE:https://meet.google.com/xyz-1234-abc"])
+    assert.strictEqual(ev.meetUrl, "https://meet.google.com/xyz-1234-abc")
+  })
+
+  it("leaves a link-free event with null meetUrl", () => {
+    const ev = parseOne(["LOCATION:Conference Room B"])
+    assert.strictEqual(ev.meetUrl, null)
+  })
+})
+
+describe("meetLabel", () => {
+  it("labels Meet and the other providers", () => {
+    assert.strictEqual(M.meetLabel("https://meet.google.com/abc-defg-hij"), "Meet")
+    assert.strictEqual(M.meetLabel("https://zoom.us/j/5550001111"), "Video")
+    assert.strictEqual(M.meetLabel("https://teams.live.com/meet/9312345678901"), "Video")
+    assert.strictEqual(M.meetLabel("https://acme.webex.com/meet/jane.doe"), "Video")
+    assert.strictEqual(M.meetLabel("https://meet.goto.com/119227189"), "Video")
+  })
+
+  it("falls back to a neutral word so the badge never renders empty", () => {
+    assert.strictEqual(M.meetLabel(null), "Video")
+    assert.strictEqual(M.meetLabel("https://example.com/whatever"), "Video")
+  })
+})
+
+describe("showOnlyWithVideoLink filter", () => {
+  it("keeps a Zoom event and drops a link-free one", () => {
+    const events = M.parseIcs([
+      "BEGIN:VCALENDAR",
+      "BEGIN:VEVENT",
+      "UID:a", "DTSTART:20260817T140000Z", "DTEND:20260817T150000Z",
+      "SUMMARY:Zoom Standup", "LOCATION:https://zoom.us/j/111", "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:b", "DTSTART:20260817T160000Z", "DTEND:20260817T170000Z",
+      "SUMMARY:Desk Lunch", "LOCATION:Kitchen", "END:VEVENT",
+      "END:VCALENDAR"
+    ].join("\r\n"), { now: NOW, lookaheadDays: 7 })
+
+    const filtered = M.buildUpcoming(events, NOW, {
+      lookaheadDays: 3, showOnlyWithVideoLink: true
+    })
+    assert.strictEqual(filtered.length, 1)
+    assert.strictEqual(filtered[0].title, "Zoom Standup")
+  })
+})


### PR DESCRIPTION
> **Depends on #14** — please merge that first. Until it lands, this PR shows its two
> commits as well; once it's in, this collapses to the two new files. 13 of these cases
> fail against `main` today, which is the point of them.

A test suite for meeting-link detection: 39 cases over the `VIDEO_PROVIDERS` table,
`findMeetUrl()`, `meetLabel()`, and the ICS properties a join link can arrive in.

Pure `node:test` and `node:assert`, no dependencies. The runtime is QML, so the suite
exercises `Model.js` through its `module.exports` guard exactly as a Node `require` does —
nothing about it assumes a Node runtime in production.

### What's covered

- **Per-provider detection** — Meet, Zoom, Teams, Webex, GoTo, including the government
  and personal-room variants
- **URL boundary handling** — HTML anchors, Outlook's angle brackets, trailing sentence
  punctuation, and bare domain mentions that must *not* match
- **RFC 5545 line folding** — feeds wrap at 75 octets, so any URL carrying a passcode
  arrives split across lines
- **The `CONFERENCE` property** (RFC 7986) and `X-MICROSOFT-SKYPETEAMSMEETINGURL`
- **Provider priority** when one event carries links for two providers
- **Google Meet regressions** — the existing behaviour, pinned
- **The `showOnlyWithVideoLink` filter** end to end, since that's what actually decides
  whether an event reaches the bar widget

### Why the fixtures look like that

Several are modelled on real Outlook, Webex and GoTo invite bodies with identifiers
replaced. The decoy links those bodies carry are the reason they're there rather than
minimal one-line fixtures: a Teams invite also links `meetingOptions` on the join host,
quotes the join URL inside angle brackets, buries the older `l/meetup-join` form under
"System reference", and — where an org runs Teams/Webex interop — includes a
`www.webex.com/msteams` link that is not a meeting. Each is a case here, so a later
widening of the patterns can't silently start joining the settings page.

The `dl/launcher` path already recognised on `main` is covered too, so it can't be
dropped unnoticed by a later edit.

Every test injects `now` explicitly rather than reading the clock, so nothing here
expires or goes flaky.

### Two notes

- **`package.json`** is added solely for the `npm test` script. It's byte-identical to the
  one in your `test/vtimezone-offset-table` branch (#9), so whichever lands first
  satisfies the other — no conflict either way. I matched that branch's layout throughout:
  `test/` and a topic-named `<area>.test.js`, alongside `test/timezones.test.js`.
- **`AGENTS.md`** currently has no test section, dropped in cdb3c1f as "suite not on main".
  That goes stale once a suite exists, but #9 restores that section too, so I've left the
  file alone rather than collide with it. Happy to add it here instead if you'd prefer it
  land with this PR.

Run with `npm test`, or directly:

```sh
node --test "test/*.test.js"
```
