### PR TITLE
feat: keyboard navigation in agenda panel

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -35,6 +35,12 @@ BarWidget {
   // e.g. "https://calendar.google.com/calendar/u/2" to open a specific
   // account (matches the u/N in your browser's calendar URL).
   readonly property string calendarUrlBase: String(setting("calendarUrlBase", "https://calendar.google.com/calendar") || "").trim()
+  // Single-key panel shortcuts (text keys while the panel is focused).
+  // Arrows and j/k/h/l are reserved by the shell's key catcher for
+  // navigation, so those letters would be dead config here.
+  readonly property string keyRefresh: Model.normalizeKey(setting("keyRefresh", "r"), "r")
+  readonly property string keyJoin: Model.normalizeKey(setting("keyJoin", "m"), "m")
+  readonly property string keyCalendar: Model.normalizeKey(setting("keyCalendar", "o"), "o")
 
   // ---- state
   readonly property bool configured: icsFeeds.length > 0

--- a/Model.js
+++ b/Model.js
@@ -979,6 +979,15 @@ function formatUpdated(date, now) {
 //   * JSON array (string or parsed QVariant) of strings or { url, label } objects
 //
 // A feed with no label gets `label` undefined so downstream renders it untagged.
+// Normalize a user-supplied single-key shortcut: trim, lowercase, accept
+// exactly one alphanumeric character, else fall back. Arrows and the shell
+// key catcher's reserved keys (j/k/h/l, Tab, Enter, Space, Escape) never
+// reach text handlers, but a reserved letter here would be dead config.
+function normalizeKey(value, fallback) {
+  var s = String(value == null ? "" : value).trim().toLowerCase()
+  return /^[a-z0-9]$/.test(s) ? s : fallback
+}
+
 function splitIcsFeeds(raw) {
   if (Array.isArray(raw)) return feedsFromArray(raw)
 
@@ -1074,6 +1083,7 @@ if (typeof module !== "undefined" && module.exports) {
     tzOffsetForWall: tzOffsetForWall,
     zonedToUtc: zonedToUtc,
     splitIcsFeeds: splitIcsFeeds,
+    normalizeKey: normalizeKey,
     dedupeEvents: dedupeEvents
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -58,13 +58,19 @@ Panel {
     heroItem.visible = configured && !!root.next
     emptyItem.visible = configured && root.scheduleGroups.length === 0
     scheduleItem.visible = configured && root.scheduleGroups.length > 0
+    root.rebuildActionItems()
   }
 
+  // Join / open-in-calendar hand off to the browser, so dismiss the panel
+  // first — regardless of whether the trigger was a click, Enter, or the
+  // m/o shortcut keys.
   function join(event) {
+    root.close()
     if (root.hostWidget && event) root.hostWidget.openEvent(event)
   }
 
   function openInCalendar(event) {
+    root.close()
     if (root.hostWidget && event) root.hostWidget.openCalendar(event)
   }
 
@@ -72,9 +78,95 @@ Panel {
     if (root.hostWidget) root.hostWidget.refresh()
   }
 
+  // ---- keyboard navigation ----
+  // Flat cursor over actionable rows in visual order: refresh, hero
+  // actions, then schedule rows. Fed by PanelKeyCatcher signals; keys
+  // only reach this panel while it holds Wayland keyboard focus, so
+  // nothing here shadows compositor-level omarchy bindings.
+  property var actionItems: []
+  property int cursorIndex: -1
+  property bool cursorActive: false
+
+  function rebuildActionItems() {
+    var items = [{ kind: "refresh" }]
+    if (heroItem.visible && root.next && root.next.meetUrl) items.push({ kind: "join" })
+    if (heroItem.visible) items.push({ kind: "calendar" })
+    for (var g = 0; g < root.scheduleGroups.length; g++) {
+      var rows = root.scheduleGroups[g].items || []
+      for (var r = 0; r < rows.length; r++) items.push({ kind: "event", groupIndex: g, rowIndex: r })
+    }
+    root.actionItems = items
+    if (root.cursorIndex >= items.length) root.cursorIndex = items.length - 1
+  }
+
+  function moveCursor(delta) {
+    if (root.actionItems.length === 0) return
+    if (!root.cursorActive) {
+      root.cursorActive = true
+      root.cursorIndex = delta > 0 ? 0 : root.actionItems.length - 1
+    } else {
+      root.cursorIndex = Math.max(0, Math.min(root.actionItems.length - 1, root.cursorIndex + delta))
+    }
+    root.ensureCursorVisible()
+  }
+
+  function activateCursor() {
+    if (!root.cursorActive || root.cursorIndex < 0 || root.cursorIndex >= root.actionItems.length) return
+    var it = root.actionItems[root.cursorIndex]
+    if (it.kind === "refresh") root.refreshNow()
+    else if (it.kind === "join") root.join(root.next)
+    else if (it.kind === "calendar") root.openInCalendar(root.next)
+    else if (it.kind === "event") {
+      var group = root.scheduleGroups[it.groupIndex]
+      if (group) root.join(group.items[it.rowIndex])
+    }
+  }
+
+  function cursorOn(kind, groupIndex, rowIndex) {
+    if (!root.cursorActive || root.cursorIndex < 0 || root.cursorIndex >= root.actionItems.length) return false
+    var it = root.actionItems[root.cursorIndex]
+    if (it.kind !== kind) return false
+    return groupIndex === undefined || (it.groupIndex === groupIndex && it.rowIndex === rowIndex)
+  }
+
+  // Mouse hover joins the same single-cursor model: hovering an actionable
+  // item moves the cursor onto it, so exactly one highlight shows at a time.
+  function pointCursorAt(kind, groupIndex, rowIndex) {
+    for (var i = 0; i < root.actionItems.length; i++) {
+      var it = root.actionItems[i]
+      if (it.kind !== kind) continue
+      if (groupIndex === undefined || (it.groupIndex === groupIndex && it.rowIndex === rowIndex)) {
+        root.cursorActive = true
+        root.cursorIndex = i
+        return
+      }
+    }
+  }
+
+  function ensureCursorVisible() {
+    if (!root.cursorActive || root.cursorIndex < 0 || root.cursorIndex >= root.actionItems.length) return
+    var it = root.actionItems[root.cursorIndex]
+    var target = null
+    if (it.kind === "refresh") target = refreshBtn
+    else if (it.kind === "join") target = joinBtn
+    else if (it.kind === "calendar") target = openCalendarBtn
+    else {
+      var group = groupRepeater.itemAt(it.groupIndex)
+      target = group ? group.rowAt(it.rowIndex) : null
+    }
+    if (!target) return
+    var top = target.mapToItem(contentColumn, 0, 0).y
+    var bottom = top + target.height
+    if (top < scroll.contentY) scroll.contentY = Math.max(0, top)
+    else if (bottom > scroll.contentY + scroll.height) scroll.contentY = bottom - scroll.height
+  }
+
   onHostWidgetChanged: Qt.callLater(root.reload)
 
-  onOpenedChanged: if (opened) root.reload()
+  onOpenedChanged: {
+    if (opened) root.reload()
+    else root.cursorActive = false
+  }
 
   Connections {
     target: root.hostWidget
@@ -96,6 +188,14 @@ Panel {
       anchors.fill: parent
       onCloseRequested: root.close()
       onTabRequested: function(direction) { root.switchPanel(direction) }
+      onMoveRequested: function(dx, dy) { if (dy !== 0) root.moveCursor(dy) }
+      onActivateRequested: root.activateCursor()
+      onTextKey: function(t) {
+        if (!root.hostWidget) return
+        if (t === root.hostWidget.keyRefresh) root.refreshNow()
+        else if (t === root.hostWidget.keyJoin && root.next && root.next.meetUrl) root.join(root.next)
+        else if (t === root.hostWidget.keyCalendar && root.next) root.openInCalendar(root.next)
+      }
 
       Flickable {
         id: scroll
@@ -159,6 +259,8 @@ Panel {
               fontFamily: root.contentFontFamily
               enabled: !root.fetching
               opacity: root.fetching ? 0.6 : 1.0
+              hasCursor: root.cursorOn("refresh")
+              onHovered: function(isHovered) { if (isHovered) root.pointCursorAt("refresh") }
               onClicked: root.refreshNow()
             }
           }
@@ -358,6 +460,8 @@ Panel {
                     iconSize: Style.font.bodySmall
                     horizontalPadding: Style.space(12)
                     verticalPadding: Style.space(7)
+                    hasCursor: root.cursorOn("join")
+                    onHovered: function(isHovered) { if (isHovered) root.pointCursorAt("join") }
                     onClicked: root.join(root.next)
                   }
 
@@ -374,6 +478,8 @@ Panel {
                     iconSize: Style.font.bodySmall
                     horizontalPadding: Style.space(12)
                     verticalPadding: Style.space(7)
+                    hasCursor: root.cursorOn("calendar")
+                    onHovered: function(isHovered) { if (isHovered) root.pointCursorAt("calendar") }
                     onClicked: root.openInCalendar(root.next)
                   }
                 }
@@ -444,6 +550,8 @@ Panel {
                   required property int index
                   readonly property var group: modelData
 
+                  function rowAt(rowIndex) { return eventRepeater.itemAt(rowIndex) }
+
                   width: parent.width
                   height: groupColumn.implicitHeight
                   implicitHeight: height
@@ -470,23 +578,24 @@ Panel {
                       id: eventRepeater
                       model: groupItem.group.items
 
-                      Rectangle {
+                      CursorSurface {
                         id: eventRow
+                        required property int index
                         required property var modelData
                         readonly property var meeting: modelData
 
                         width: parent.width
-                        radius: Style.cornerRadius
-                        color: rowMouse.containsMouse
-                          ? Style.hoverFillFor(root.contentForeground, Color.accent)
-                          : "transparent"
                         implicitHeight: Math.max(Style.space(32), rowLayout.implicitHeight + Style.space(8))
+                        hasCursor: root.cursorOn("event", groupItem.index, index)
+                        foreground: root.contentForeground
+                        accent: Color.accent
 
                         MouseArea {
                           id: rowMouse
                           anchors.fill: parent
                           hoverEnabled: true
                           cursorShape: Qt.PointingHandCursor
+                          onEntered: root.pointCursorAt("event", groupItem.index, index)
                           onClicked: root.join(meeting)
                         }
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ upcoming event from your calendar with live countdowns and lets you join video c
 - **Bar Widget**: Shows the next event with live countdown (`Daily in 15 min`, `Daily · 15 min left`, `Daily · 14:00`, `Daily · Tmrw 14:00`, `Daily · Wed 14:00`)
 - **Quick Join**: Click to open the agenda panel; single click on "Join Meeting" opens the video link (Google Meet, Zoom, Teams, Webex, GoToMeeting) in your default browser
 - **Instant Actions**: Right-click on the bar widget to join the next meeting immediately; middle-click to force-refresh
+- **Keyboard Navigation**: With the agenda panel open, `↑`/`↓` (or `j`/`k`) move through the refresh button, hero actions, and event rows, `Enter`/`Space` activates, `r` refreshes, `m` joins the next meeting, `o` opens it in the calendar, `Tab`/`Shift+Tab` switch panels, `Escape` closes — all scoped to the focused panel so no Omarchy keybinding is ever shadowed
+- **Summon Keybinding**: Bind a global key to open the agenda panel (see [Opening the panel from the keyboard](#opening-the-panel-from-the-keyboard))
 - **Repeating Events**: Automatically expands repeating events (daily standups, weekly meetings) and respects cancelled or rescheduled instances
 - **Live Updates**: Automatic background sync every few minutes, with a 30-second reactive countdown timer
 
@@ -116,6 +118,40 @@ Available settings (`omarchy bar set <widget> <key> <value>`):
 | `showOnlyWithVideoLink` | `true` | Only show meetings that have a video link          |
 | `browserCommand`      | `""`    | Command used to open the Meet URL (`xdg-open` by default) |
 | `calendarUrlBase`     | `"https://calendar.google.com/calendar"` | Base URL for "Open in Calendar" (opens `/r` route; set e.g. `https://calendar.google.com/calendar/u/1` for multi-account) |
+| `keyRefresh`          | `r`     | Panel key that force-refreshes the feeds            |
+| `keyJoin`             | `m`     | Panel key that joins the next meeting               |
+| `keyCalendar`         | `o`     | Panel key that opens the next meeting in the calendar |
+
+Keys must be a single letter or digit. Arrows and `j`/`k`/`h`/`l` are reserved
+for panel navigation and cannot be rebound.
+
+## Opening the panel from the keyboard
+
+The panel opens by clicking the bar widget, but you can bind a global key to
+it. Add this to `~/.config/hypr/bindings.lua` (pick any combo you like —
+`SUPER + CTRL + M` is free in the default Omarchy config):
+
+```lua
+o.bind("SUPER + CTRL + M", "Next event", "omarchy-shell shell toggle tobiasz-p.next-event")
+```
+
+### Panel keyboard shortcuts
+
+While the agenda panel is open it grabs the keyboard, so these never clash
+with your applications or Omarchy bindings:
+
+| Key                  | Action                                              |
+| -------------------- | --------------------------------------------------- |
+| `↑` / `↓` or `j`/`k` | Move through refresh button, hero actions, event rows |
+| `Enter` / `Space`    | Activate the highlighted item                       |
+| `r`                  | Refresh feeds now (`keyRefresh`)                    |
+| `m`                  | Join the next meeting (`keyJoin`)                   |
+| `o`                  | Open the next meeting in the calendar (`keyCalendar`) |
+| `Tab` / `Shift+Tab`  | Switch to the previous/next bar panel               |
+| `Escape`             | Close the panel                                     |
+
+Joining and opening the calendar dismiss the panel as they hand off to the
+browser; refreshing keeps it open.
 
 ## Privacy
 


### PR DESCRIPTION
Navigate the agenda without a mouse: arrows or vim-style j/k move
through the refresh button, hero actions, and every event row; Enter or
Space activates, Tab switches panels, Escape closes. A single cursor is
shared between mouse hover and the keyboard via the shell's shared
CursorSurface chrome, so exactly one row is ever highlighted.

Shortcut keys: r refreshes feeds, m joins the next meeting, o opens it
in the calendar (rebindable via keyRefresh/keyJoin/keyCalendar settings;
arrows and j/k/h/l stay reserved for navigation). Join and calendar
actions dismiss the panel as they hand off to the browser.

The panel can also be opened from anywhere with a Hyprland bind, e.g.
SUPER+CTRL+M -> omarchy-shell shell toggle tobiasz-p.next-event.
