### PR TITLE
fix: increase calendar feed size limit

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -23,6 +23,7 @@ BarWidget {
   readonly property int refreshMinutes: Math.max(1, parseInt(setting("refreshMinutes", 5), 10) || 5)
   readonly property int showDaysAhead: Math.max(1, parseInt(setting("showDaysAhead", 3), 10) || 3)
   readonly property int maxTitleLength: Math.max(8, parseInt(setting("maxTitleLength", 28), 10) || 28)
+  readonly property int maxFeedSizeMiB: Math.max(1, parseInt(setting("maxFeedSizeMiB", 10), 10) || 10)
   readonly property bool showOnlyWithVideoLink: {
     var v = setting("showOnlyWithVideoLink", true)
     if (v === undefined || v === null) return true
@@ -131,7 +132,7 @@ BarWidget {
       return
     }
     fetchProc.stdinEnabled = true
-    fetchProc.command = ["curl", "-fsSL", "--max-time", "15", "--max-filesize", "1048576", "-K", "-"]
+    fetchProc.command = ["curl", "-fsSL", "--max-time", "15", "--max-filesize", String(root.maxFeedSizeMiB * 1024 * 1024), "-K", "-"]
     fetchProc.running = true
   }
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Available settings (`omarchy bar set <widget> <key> <value>`):
 | `refreshMinutes`      | `5`     | How often to refetch the feeds                      |
 | `showDaysAhead`       | `3`     | How many days ahead to list meetings                |
 | `maxTitleLength`      | `28`    | Bar label truncation length                         |
+| `maxFeedSizeMiB`      | `10`    | Maximum size of each downloaded calendar feed (MiB) |
 | `showOnlyWithVideoLink` | `true` | Only show meetings that have a video link          |
 | `browserCommand`      | `""`    | Command used to open the Meet URL (`xdg-open` by default) |
 | `calendarUrlBase`     | `"https://calendar.google.com/calendar"` | Base URL for "Open in Calendar" (opens `/r` route; set e.g. `https://calendar.google.com/calendar/u/1` for multi-account) |
@@ -219,4 +220,3 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/). Write co
 ## License
 
 MIT
-


### PR DESCRIPTION
## Summary
- raise the default per-feed download limit from 1 MiB to 10 MiB
- make the limit configurable with `maxFeedSizeMiB`
- document the new setting

## Validation
- verified two Google Calendar iCal feeds (2.88 MB and 1.27 MB) download successfully under the new default limit