### PR TITLE
feat: add configurable 12-hour time display

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -23,6 +23,8 @@ BarWidget {
   readonly property int refreshMinutes: Math.max(1, parseInt(setting("refreshMinutes", 5), 10) || 5)
   readonly property int showDaysAhead: Math.max(1, parseInt(setting("showDaysAhead", 3), 10) || 3)
   readonly property int maxTitleLength: Math.max(8, parseInt(setting("maxTitleLength", 28), 10) || 28)
+  // Opt-in to AM/PM; 24-hour output remains the default for compatibility.
+  readonly property bool use12Hour: String(setting("timeFormat", "24")).toLowerCase() === "12"
   readonly property int maxFeedSizeMiB: Math.max(1, parseInt(setting("maxFeedSizeMiB", 10), 10) || 10)
   readonly property bool showOnlyWithVideoLink: {
     var v = setting("showOnlyWithVideoLink", true)
@@ -67,7 +69,7 @@ BarWidget {
   property string feedOutput: ""
 
   readonly property string label: configured && nextMeeting
-    ? (nextMeeting.meetUrl ? "  " : "󰃯  ") + Model.formatLabel(nextMeeting, root.now, maxTitleLength)
+    ? (nextMeeting.meetUrl ? "  " : "󰃯  ") + Model.formatLabel(nextMeeting, root.now, maxTitleLength, root.use12Hour)
     : ""
   readonly property bool inMeeting: nextMeeting
     && nextMeeting.start && nextMeeting.end
@@ -345,8 +347,8 @@ BarWidget {
       return "NextEvent — No upcoming events"
     }
     var title = root.nextMeeting.title || "(Untitled)"
-    var range = Model.timeRange(root.nextMeeting.start, root.nextMeeting.end)
-    var status = Model.relativeStatus(root.nextMeeting, root.now)
+    var range = Model.timeRange(root.nextMeeting.start, root.nextMeeting.end, root.use12Hour)
+    var status = Model.relativeStatus(root.nextMeeting, root.now, root.use12Hour)
     var line = title + " · " + range + (status ? " (" + status + ")" : "")
     if (root.nextMeeting.feedLabel) line = root.nextMeeting.feedLabel + " · " + line
     if (root.lastFetchFailed) line += " · Offline"

--- a/Model.js
+++ b/Model.js
@@ -766,20 +766,27 @@ function isSameDay(a, b) {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate()
 }
 
-function hm(date) {
-  return pad2(date.getHours()) + ":" + pad2(date.getMinutes())
+// Explicit formatting keeps this compatible with QML V4 (which has no Intl).
+// The default remains the historic 24-hour display.
+function hm(date, use12Hour) {
+  var hour = date.getHours()
+  if (use12Hour === true) {
+    var suffix = hour >= 12 ? "PM" : "AM"
+    var displayHour = hour % 12
+    if (displayHour === 0) displayHour = 12
+    return displayHour + ":" + pad2(date.getMinutes()) + " " + suffix
+  }
+  return pad2(hour) + ":" + pad2(date.getMinutes())
 }
 
-function shortStart(date) {
-  return hm(date)
-}
+function shortStart(date, use12Hour) { return hm(date, use12Hour) }
 
-function timeRange(start, end) {
+function timeRange(start, end, use12Hour) {
   if (!start) return ""
-  return hm(start) + "–" + hm(end)
+  return hm(start, use12Hour) + "–" + hm(end, use12Hour)
 }
 
-function meetingTimeLabel(start, end, now) {
+function meetingTimeLabel(start, end, now, use12Hour) {
   var labels = []
   if (isSameDay(start, now)) labels.push("Today")
   else if (isSameDay(start, new Date(now.getTime() + 86400000))) labels.push("Tomorrow")
@@ -788,18 +795,18 @@ function meetingTimeLabel(start, end, now) {
     var mo = MONTH_NAMES_SHORT[start.getMonth()]
     labels.push(dow + " " + start.getDate() + " " + mo)
   }
-  if (start && end) labels.push(timeRange(start, end))
+  if (start && end) labels.push(timeRange(start, end, use12Hour))
   return labels.join(" · ")
 }
 
-function relativeStatus(next, now) {
+function relativeStatus(next, now, use12Hour) {
   if (!next || !next.start || !next.end) return ""
   var start = next.start.getTime()
   var end = next.end.getTime()
   var t = now.getTime()
   if (t < start) {
     var mins = Math.max(1, Math.round((start - t) / 60000))
-    return mins >= 60 ? "starts at " + hm(next.start) : "starts in " + mins + " min"
+    return mins >= 60 ? "starts at " + hm(next.start, use12Hour) : "starts in " + mins + " min"
   }
   if (t < end) {
     var left = Math.max(1, Math.round((end - t) / 60000))
@@ -828,7 +835,7 @@ function startOfDay(date) {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
 }
 
-function formatLabel(next, now, maxTitleLength) {
+function formatLabel(next, now, maxTitleLength, use12Hour) {
   if (!next || !next.start) return ""
   var title = String(next.title || "(Untitled)")
   var limit = Math.max(8, parseInt(maxTitleLength, 10) || 28)
@@ -851,8 +858,8 @@ function formatLabel(next, now, maxTitleLength) {
     var mins = Math.max(1, Math.round((start - t) / 60000))
     suffix = mins <= 1 ? " · in a min" : " · in " + mins + " min"
   } else {
-    suffix = " · " + hm(next.start)
-    if (!isSameDay(next.start, now)) suffix = " · " + dayLabel(next.start, now) + " " + hm(next.start)
+    suffix = " · " + hm(next.start, use12Hour)
+    if (!isSameDay(next.start, now)) suffix = " · " + dayLabel(next.start, now) + " " + hm(next.start, use12Hour)
   }
   var titleLimit = Math.max(3, limit - suffix.length)
   if (title.length > titleLimit) title = title.slice(0, Math.max(1, titleLimit - 1)) + "…"
@@ -979,14 +986,14 @@ function eventCalendarUrl(ev, base) {
   return b + "/r"
 }
 
-function formatUpdated(date, now) {
+function formatUpdated(date, now, use12Hour) {
   if (!date || isNaN(date.getTime()) || date.getTime() <= 0) return ""
   var mins = Math.floor((now.getTime() - date.getTime()) / 60000)
   if (mins < 1) return "just now"
   if (mins < 60) return mins + "m ago"
   var hours = Math.floor(mins / 60)
   if (hours < 24) return hours + "h ago"
-  return hm(date)
+  return hm(date, use12Hour)
 }
 
 // --- multiple ICS feeds -----------------------------------------------------

--- a/Panel.qml
+++ b/Panel.qml
@@ -241,7 +241,7 @@ Panel {
                 if (root.offlineFeedCount > 0)
                   return root.offlineFeedCount + " calendar" + (root.offlineFeedCount > 1 ? "s" : "") + " offline · updated"
                 if (root.hostWidget && root.hostWidget.configured)
-                  return Model.formatUpdated(root.hostWidget.lastUpdated, root.now)
+                  return Model.formatUpdated(root.hostWidget.lastUpdated, root.now, root.hostWidget.use12Hour)
                 return ""
               }
               color: (root.lastFetchFailed || root.offlineFeedCount > 0) ? Color.urgent : Qt.darker(root.contentForeground, 1.5)
@@ -434,8 +434,8 @@ Panel {
                 Text {
                   width: parent.width
                   text: root.next
-                    ? Model.meetingTimeLabel(root.next.start, root.next.end, root.now)
-                      + (Model.relativeStatus(root.next, root.now) ? " · " + Model.relativeStatus(root.next, root.now) : "")
+                    ? Model.meetingTimeLabel(root.next.start, root.next.end, root.now, root.hostWidget.use12Hour)
+                      + (Model.relativeStatus(root.next, root.now, root.hostWidget.use12Hour) ? " · " + Model.relativeStatus(root.next, root.now, root.hostWidget.use12Hour) : "")
                     : ""
                   color: Qt.darker(root.contentForeground, 1.35)
                   font.family: root.contentFontFamily
@@ -611,7 +611,7 @@ Panel {
                           Text {
                             Layout.alignment: Qt.AlignVCenter
                             Layout.preferredWidth: Style.space(44)
-                            text: Model.hm(meeting.start)
+                            text: Model.hm(meeting.start, root.hostWidget.use12Hour)
                             color: Qt.darker(root.contentForeground, 1.3)
                             font.family: root.contentFontFamily
                             font.pixelSize: Style.font.bodySmall

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ upcoming event from your calendar with live countdowns and lets you join video c
 - **Theme Aware**: Fully syncs with your active Omarchy theme (colors, typography, borders, and corner rounding adapt automatically)
 - **Universal Calendar Support**: Works with standard `.ics` feeds from Google Calendar, Microsoft Outlook, Apple iCloud, Nextcloud, Proton, and custom URLs
 - **Multiple Calendars**: Combine several `.ics` feeds (e.g. work + personal) into one widget. Give each feed a `label|` name so events carry a small tag, shared events are deduplicated, and one offline calendar doesn't hide the rest
-- **Bar Widget**: Shows the next event with live countdown (`Daily in 15 min`, `Daily · 15 min left`, `Daily · 14:00`, `Daily · Tmrw 14:00`, `Daily · Wed 14:00`)
+- **Bar Widget**: Shows the next event with live countdown (`Daily in 15 min`, `Daily · 15 min left`, `Daily · 14:00`, `Daily · Tmrw 14:00`, `Daily · Wed 14:00`). Set `timeFormat` to `12` for AM/PM times.
 - **Quick Join**: Click to open the agenda panel; single click on "Join Meeting" opens the video link (Google Meet, Zoom, Teams, Webex, GoToMeeting) in your default browser
 - **Instant Actions**: Right-click on the bar widget to join the next meeting immediately; middle-click to force-refresh
 - **Keyboard Navigation**: With the agenda panel open, `↑`/`↓` (or `j`/`k`) move through the refresh button, hero actions, and event rows, `Enter`/`Space` activates, `r` refreshes, `m` joins the next meeting, `o` opens it in the calendar, `Tab`/`Shift+Tab` switch panels, `Escape` closes — all scoped to the focused panel so no Omarchy keybinding is ever shadowed
@@ -115,6 +115,7 @@ Available settings (`omarchy bar set <widget> <key> <value>`):
 | `refreshMinutes`      | `5`     | How often to refetch the feeds                      |
 | `showDaysAhead`       | `3`     | How many days ahead to list meetings                |
 | `maxTitleLength`      | `28`    | Bar label truncation length                         |
+| `timeFormat`          | `24`    | Time display format: `24` (24-hour) or `12` (AM/PM) |
 | `maxFeedSizeMiB`      | `10`    | Maximum size of each downloaded calendar feed (MiB) |
 | `showOnlyWithVideoLink` | `true` | Only show meetings that have a video link          |
 | `browserCommand`      | `""`    | Command used to open the Meet URL (`xdg-open` by default) |

--- a/test/time-format.test.js
+++ b/test/time-format.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const Model = require('../Model.js')
+
+const date = (hour, minute = 5) => new Date(2024, 0, 2, hour, minute)
+
+test('hm preserves 24-hour output by default', () => {
+  assert.equal(Model.hm(date(0)), '00:05')
+  assert.equal(Model.hm(date(13)), '13:05')
+})
+
+test('hm formats midnight, noon, and afternoon as 12-hour time', () => {
+  assert.equal(Model.hm(date(0), true), '12:05 AM')
+  assert.equal(Model.hm(date(12), true), '12:05 PM')
+  assert.equal(Model.hm(date(13), true), '1:05 PM')
+})
+
+test('time ranges and labels accept 12-hour formatting', () => {
+  assert.equal(Model.timeRange(date(9), date(10, 35), true), '9:05 AM–10:35 AM')
+  assert.match(Model.meetingTimeLabel(date(13), date(14), date(13), true), /1:05 PM–2:05 PM/)
+})


### PR DESCRIPTION
## Summary
- add an opt-in `timeFormat` setting for 12-hour AM/PM display
- apply the format consistently in the bar, tooltip, and agenda panel
- preserve the existing 24-hour default and QML V4 compatibility
- add formatting tests and documentation

## Testing
- `npm test` (42 passing)