### PR TITLE
feat: prioritize short events over all-day events

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -98,6 +98,7 @@ BarWidget {
     ? (nextMeeting.meetUrl ? "  " : "󰃯  ") + Model.formatLabel(nextMeeting, root.now, maxTitleLength)
     : ""
   readonly property bool inMeeting: nextMeeting
+    && !nextMeeting.allDay
     && nextMeeting.start && nextMeeting.end
     && root.now.getTime() >= nextMeeting.start.getTime()
     && root.now.getTime() < nextMeeting.end.getTime()
@@ -434,7 +435,7 @@ BarWidget {
       return "NextEvent — No upcoming events"
     }
     var title = root.nextMeeting.title || "(Untitled)"
-    var range = Model.timeRange(root.nextMeeting.start, root.nextMeeting.end)
+    var range = Model.timeRange(root.nextMeeting.start, root.nextMeeting.end, root.nextMeeting.allDay)
     var status = Model.relativeStatus(root.nextMeeting, root.now)
     var line = title + " · " + range + (status ? " (" + status + ")" : "")
     if (root.showCalendarLabel && root.nextMeeting.feedLabel) line = root.nextMeeting.feedLabel + " · " + line

--- a/Model.js
+++ b/Model.js
@@ -161,15 +161,33 @@ function weekdayOfKey(key) {
 // QML's V4 engine has no Intl, so named zones must be resolved from the
 // VTIMEZONE blocks the feed itself ships.
 
-// RFC 5545 offset/rule units, and how far either side of a target year the
-// transition search must look (DST observances always repeat yearly).
 var MS_PER_SECOND = 1000
 var SECONDS_PER_MINUTE = 60
 var MINUTES_PER_HOUR = 60
+var HOURS_PER_DAY = 24
 var DAYS_PER_WEEK = 7
+var MS_PER_MINUTE = SECONDS_PER_MINUTE * MS_PER_SECOND
+var MS_PER_HOUR = MINUTES_PER_HOUR * MS_PER_MINUTE
+var MS_PER_DAY = HOURS_PER_DAY * MS_PER_HOUR
 var TRANSITION_YEAR_MARGIN = 1
 
+var MAX_RRULE_STEPS = 20000
+var DEFAULT_LOOKAHEAD_DAYS = 3
+var DEFAULT_MAX_EVENTS = 80
+var DEFAULT_MAX_ROWS = 20
+var DEFAULT_MAX_TITLE_LENGTH = 28
+var MIN_MAX_TITLE_LENGTH = 8
+var MIN_TITLE_CHARS = 3
+
 var LABEL_ALL_DAY = "All day"
+var LABEL_TODAY = "Today"
+var LABEL_TOMORROW = "Tomorrow"
+var LABEL_YESTERDAY = "Yest"
+var LABEL_UNTITLED = "(Untitled)"
+var LABEL_VIDEO_DEFAULT = "Video"
+var LABEL_JUST_NOW = "just now"
+var SECTION_TODAY = "TODAY"
+var SECTION_TOMORROW = "TOMORROW"
 
 var TZ_TABLE = {}
 
@@ -469,7 +487,6 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
   var out = []
   var toKey = addDaysToKey(fromKey, lookaheadDays)
   var startParts = keyToParts(startKey)
-  var MAX_STEPS = 20000
 
   function pushKey(key) {
     if (key < startKey || key < fromKey || key > toKey) return
@@ -501,7 +518,7 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
 
   if (rule.freq === "DAILY") {
     for (key = startKey; key <= toKey; key = addDaysToKey(key, rule.interval)) {
-      if (++guard > MAX_STEPS) break
+      if (++guard > MAX_RRULE_STEPS) break
       var wd = weekdayOfKey(key)
       var hit = rule.byday.length === 0
       for (i = 0; i < rule.byday.length; i++) {
@@ -524,7 +541,7 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
       offsets.push((weekdayOfKey(startKey) - WEEKDAY.MO + 7) % 7)
     }
     for (weekKey = firstWeek; weekKey <= toKey; weekKey = addDaysToKey(weekKey, rule.interval * 7)) {
-      if (++guard > MAX_STEPS) break
+      if (++guard > MAX_RRULE_STEPS) break
       for (i = 0; i < offsets.length; i++) {
         var wk = addDaysToKey(weekKey, offsets[i])
         if (wk < startKey) continue
@@ -535,7 +552,7 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
     }
   } else if (rule.freq === "MONTHLY") {
     var idx = startParts.y * 12 + (startParts.mo - 1)
-    for (var step = 0; step < MAX_STEPS; step++) {
+    for (var step = 0; step < MAX_RRULE_STEPS; step++) {
       var y = Math.floor((idx + step * rule.interval) / 12)
       var mo = ((idx + step * rule.interval) % 12) + 1
       var candidates = monthCandidates(y, mo, rule, startKey, toKey, startParts.d)
@@ -547,7 +564,7 @@ function expandOccurrences(startKey, tzInfo, rule, fromKey, lookaheadDays, maxOc
       if (dayKey(y, mo, daysInMonthUTC(y, mo)) > toKey) break
     }
   } else if (rule.freq === "YEARLY") {
-    for (var yi = 0; yi < MAX_STEPS; yi++) {
+    for (var yi = 0; yi < MAX_RRULE_STEPS; yi++) {
       var yy = startParts.y + yi * rule.interval
       var months = rule.bymonth.length ? rule.bymonth : [startParts.mo]
       for (var mi = 0; mi < months.length; mi++) {
@@ -572,18 +589,18 @@ var VIDEO_PROVIDERS = [
   { re: /https:\/\/meet\.google\.com\/[a-z0-9][a-z0-9-]*/, label: "Meet" },
   // Vanity subdomains (us02web., <company>.), /j/ meetings, /w/ and /s/ webinars,
   // /my/ personal rooms, on both the commercial domain and Zoom for Government.
-  { re: /https?:\/\/(?:[\w-]+\.)*(?:zoom\.us|zoomgov\.com)\/(?:j|w|s|my)\/[^\s"'<>]+/, label: "Video" },
+  { re: /https?:\/\/(?:[\w-]+\.)*(?:zoom\.us|zoomgov\.com)\/(?:j|w|s|my)\/[^\s"'<>]+/, label: LABEL_VIDEO_DEFAULT },
   // Commercial, personal (teams.live.com) and government (GCC High / DoD, on
   // teams.microsoft.us) tenants. Paths stay restricted: an Outlook invite body
   // also links teams.microsoft.com/meetingOptions/… below the join link, so a
   // domain-only match would join the settings page.
-  { re: /https?:\/\/(?:teams\.microsoft\.com|teams\.live\.com|(?:[\w-]+\.)?teams\.microsoft\.us)\/(?:l\/meetup-join|l\/meeting|meet|dl\/launcher)\/[^\s"'<>]+/, label: "Video" },
+  { re: /https?:\/\/(?:teams\.microsoft\.com|teams\.live\.com|(?:[\w-]+\.)?teams\.microsoft\.us)\/(?:l\/meetup-join|l\/meeting|meet|dl\/launcher)\/[^\s"'<>]+/, label: LABEL_VIDEO_DEFAULT },
   // Personal rooms (/meet/, /join/) and the hosted-site form,
   // <company>.webex.com/<site>/j.php?MTID=… — the site segment sits before j.php.
-  { re: /https?:\/\/(?:[\w-]+\.)*webex\.com\/(?:meet\/|join\/|[^\s"'<>]*j\.php\?)[^\s"'<>]+/, label: "Video" },
+  { re: /https?:\/\/(?:[\w-]+\.)*webex\.com\/(?:meet\/|join\/|[^\s"'<>]*j\.php\?)[^\s"'<>]+/, label: LABEL_VIDEO_DEFAULT },
   // meet.goto.com and gotomeet.me host nothing but meetings, so any path will do.
   // gotomeeting.com also serves marketing pages, hence /join/.
-  { re: /https?:\/\/(?:(?:meet\.goto\.com|(?:www\.)?gotomeet\.me)\/[^\s"'<>]+|(?:[\w-]+\.)*gotomeeting\.com\/join\/[^\s"'<>]+)/, label: "Video" },
+  { re: /https?:\/\/(?:(?:meet\.goto\.com|(?:www\.)?gotomeet\.me)\/[^\s"'<>]+|(?:[\w-]+\.)*gotomeeting\.com\/join\/[^\s"'<>]+)/, label: LABEL_VIDEO_DEFAULT },
 ]
 
 // Sentence punctuation trailing a URL belongs to the prose, not the link.
@@ -601,12 +618,12 @@ function findMeetUrl(text) {
 }
 
 function meetLabel(url) {
-  if (!url) return "Video"
+  if (!url) return LABEL_VIDEO_DEFAULT
   var s = String(url)
   for (var i = 0; i < VIDEO_PROVIDERS.length; i++) {
     if (VIDEO_PROVIDERS[i].re.test(s)) return VIDEO_PROVIDERS[i].label
   }
-  return "Video"
+  return LABEL_VIDEO_DEFAULT
 }
 
 function parseEventBlock(block) {
@@ -707,8 +724,8 @@ function parseEventBlock(block) {
 
 function parseIcs(raw, options) {
   options = options || {}
-  var lookaheadDays = Math.max(1, parseInt(options.lookaheadDays, 10) || 3)
-  var maxOccurrences = Math.max(1, parseInt(options.maxEvents, 10) || 80)
+  var lookaheadDays = Math.max(1, parseInt(options.lookaheadDays, 10) || DEFAULT_LOOKAHEAD_DAYS)
+  var maxOccurrences = Math.max(1, parseInt(options.maxEvents, 10) || DEFAULT_MAX_EVENTS)
   var now = options.now || new Date()
   var fromKey = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate()
 
@@ -774,7 +791,7 @@ function parseIcs(raw, options) {
       var startDate = overrideEv ? overrideEv.start : occStart
       var endDate = overrideEv ? overrideEv.end : new Date(startMs + master.durationMs)
       if (endDate.getTime() <= startDate.getTime())
-        endDate = new Date(startDate.getTime() + 3600000)
+        endDate = new Date(startDate.getTime() + MS_PER_HOUR)
       result.push({
         uid: master.uid,
         title: src.title,
@@ -910,10 +927,10 @@ function timeRange(start, end, allDay) {
 }
 
 function meetingTimeLabel(start, end, now, allDay) {
-  var isAllDay = allDay === true || (start && end && (end.getTime() - start.getTime()) >= 86400000 && start.getHours() === 0 && start.getMinutes() === 0 && end.getHours() === 0 && end.getMinutes() === 0)
+  var isAllDay = allDay === true || (start && end && (end.getTime() - start.getTime()) >= MS_PER_DAY && start.getHours() === 0 && start.getMinutes() === 0 && end.getHours() === 0 && end.getMinutes() === 0)
   var labels = []
-  if (isSameDay(start, now)) labels.push("Today")
-  else if (isSameDay(start, new Date(now.getTime() + MS_PER_DAY))) labels.push("Tomorrow")
+  if (isSameDay(start, now)) labels.push(LABEL_TODAY)
+  else if (isSameDay(start, new Date(now.getTime() + MS_PER_DAY))) labels.push(LABEL_TOMORROW)
   else {
     var dow = WEEKDAY_NAMES[start.getDay()]
     var mo = MONTH_NAMES_SHORT[start.getMonth()]
@@ -947,15 +964,15 @@ function relativeStatus(next, now) {
   var end = next.end.getTime()
   var t = now.getTime()
   if (t < start) {
-    var mins = Math.max(1, Math.round((start - t) / 60000))
-    return mins >= 60 ? "starts at " + hm(next.start) : "starts in " + mins + " min"
+    var mins = Math.max(1, Math.round((start - t) / MS_PER_MINUTE))
+    return mins >= MINUTES_PER_HOUR ? "starts at " + hm(next.start) : "starts in " + mins + " min"
   }
   if (t < end) {
-    var left = Math.max(1, Math.round((end - t) / 60000))
+    var left = Math.max(1, Math.round((end - t) / MS_PER_MINUTE))
     if (left <= 1) return "1 min left"
-    if (left < 60) return left + " min left"
-    var h = Math.floor(left / 60)
-    var m = left % 60
+    if (left < MINUTES_PER_HOUR) return left + " min left"
+    var h = Math.floor(left / MINUTES_PER_HOUR)
+    var m = left % MINUTES_PER_HOUR
     return (m > 0 ? h + "h " + m + "m" : h + "h") + " left"
   }
   return ""
@@ -963,10 +980,10 @@ function relativeStatus(next, now) {
 
 function dayLabel(start, now) {
   var dayDiff = Math.round((startOfDay(start) - startOfDay(now)) / MS_PER_DAY)
-  if (dayDiff === 0) return "Today"
+  if (dayDiff === 0) return LABEL_TODAY
   if (dayDiff === 1) return "Tmrw"
-  if (dayDiff === -1) return "Yest"
-  if (dayDiff > 1 && dayDiff < 7) return WEEKDAY_NAMES[start.getDay()]
+  if (dayDiff === -1) return LABEL_YESTERDAY
+  if (dayDiff > 1 && dayDiff < DAYS_PER_WEEK) return WEEKDAY_NAMES[start.getDay()]
   var dow = WEEKDAY_NAMES[start.getDay()]
   var mo = MONTH_NAMES_SHORT[start.getMonth()]
   return dow + " " + start.getDate() + " " + mo
@@ -978,8 +995,8 @@ function startOfDay(date) {
 
 function formatLabel(next, now, maxTitleLength) {
   if (!next || !next.start) return ""
-  var title = String(next.title || "(Untitled)")
-  var limit = Math.max(8, parseInt(maxTitleLength, 10) || 28)
+  var title = String(next.title || LABEL_UNTITLED)
+  var limit = Math.max(MIN_MAX_TITLE_LENGTH, parseInt(maxTitleLength, 10) || DEFAULT_MAX_TITLE_LENGTH)
   var suffix
   var start = next.start.getTime()
   var end = next.end ? next.end.getTime() : start
@@ -991,24 +1008,24 @@ function formatLabel(next, now, maxTitleLength) {
       suffix = " · " + dayLabel(next.start, now) + " " + LABEL_ALL_DAY
     }
   } else if (t >= start && t < end) {
-    var minsLeft = Math.max(1, Math.round((end - t) / 60000))
+    var minsLeft = Math.max(1, Math.round((end - t) / MS_PER_MINUTE))
     if (minsLeft <= 1) {
       suffix = " · 1 min left"
-    } else if (minsLeft < 60) {
+    } else if (minsLeft < MINUTES_PER_HOUR) {
       suffix = " · " + minsLeft + " min left"
     } else {
-      var h = Math.floor(minsLeft / 60)
-      var m = minsLeft % 60
+      var h = Math.floor(minsLeft / MINUTES_PER_HOUR)
+      var m = minsLeft % MINUTES_PER_HOUR
       suffix = " · " + (m > 0 ? h + "h " + m + "m" : h + "h") + " left"
     }
-  } else if (start - t <= 60 * 60000 && start > t) {
-    var mins = Math.max(1, Math.round((start - t) / 60000))
+  } else if (start - t <= MS_PER_HOUR && start > t) {
+    var mins = Math.max(1, Math.round((start - t) / MS_PER_MINUTE))
     suffix = mins <= 1 ? " · in a min" : " · in " + mins + " min"
   } else {
     suffix = " · " + hm(next.start)
     if (!isSameDay(next.start, now)) suffix = " · " + dayLabel(next.start, now) + " " + hm(next.start)
   }
-  var titleLimit = Math.max(3, limit - suffix.length)
+  var titleLimit = Math.max(MIN_TITLE_CHARS, limit - suffix.length)
   if (title.length > titleLimit) title = title.slice(0, Math.max(1, titleLimit - 1)) + "…"
   return title + suffix
 }
@@ -1033,9 +1050,9 @@ function compareUpcoming(a, b, now) {
 
 function buildUpcoming(events, now, options) {
   options = options || {}
-  var lookaheadDays = Math.max(1, parseInt(options.lookaheadDays, 10) || 3)
+  var lookaheadDays = Math.max(1, parseInt(options.lookaheadDays, 10) || DEFAULT_LOOKAHEAD_DAYS)
   var showOnlyWithVideoLink = options.showOnlyWithVideoLink === true
-  var maxRows = Math.max(1, parseInt(options.maxRows, 10) || 20)
+  var maxRows = Math.max(1, parseInt(options.maxRows, 10) || DEFAULT_MAX_ROWS)
   var t = now.getTime()
   var horizon = t + lookaheadDays * MS_PER_DAY
 
@@ -1057,18 +1074,18 @@ function buildUpcoming(events, now, options) {
 
 function formatDuration(start, end) {
   if (!start || !end) return ""
-  var mins = Math.round((end.getTime() - start.getTime()) / 60000)
+  var mins = Math.round((end.getTime() - start.getTime()) / MS_PER_MINUTE)
   if (mins <= 0) return ""
-  if (mins < 60) return mins + "m"
-  var h = Math.floor(mins / 60)
-  var m = mins % 60
+  if (mins < MINUTES_PER_HOUR) return mins + "m"
+  var h = Math.floor(mins / MINUTES_PER_HOUR)
+  var m = mins % MINUTES_PER_HOUR
   return m > 0 ? h + "h " + m + "m" : h + "h"
 }
 
 function daySectionTitle(date, now) {
   var diff = Math.round((startOfDay(date) - startOfDay(now)) / MS_PER_DAY)
-  if (diff === 0) return "TODAY"
-  if (diff === 1) return "TOMORROW"
+  if (diff === 0) return SECTION_TODAY
+  if (diff === 1) return SECTION_TOMORROW
   var dow = WEEKDAY_NAMES[date.getDay()].toUpperCase()
   var mo = MONTH_NAMES_SHORT[date.getMonth()].toUpperCase()
   return dow + " " + date.getDate() + " " + mo
@@ -1077,8 +1094,8 @@ function daySectionTitle(date, now) {
 // Group upcoming events into day sections (TODAY, TOMORROW, DOW DD MMM)
 function buildScheduleGroups(events, now, options) {
   options = options || {}
-  var lookaheadDays = Math.max(1, parseInt(options.lookaheadDays, 10) || 3)
-  var maxRows = Math.max(1, parseInt(options.maxRows, 10) || 20)
+  var lookaheadDays = Math.max(1, parseInt(options.lookaheadDays, 10) || DEFAULT_LOOKAHEAD_DAYS)
+  var maxRows = Math.max(1, parseInt(options.maxRows, 10) || DEFAULT_MAX_ROWS)
   var t = now.getTime()
   var horizon = t + lookaheadDays * MS_PER_DAY
 
@@ -1145,11 +1162,11 @@ function eventCalendarUrl(ev, base) {
 
 function formatUpdated(date, now) {
   if (!date || isNaN(date.getTime()) || date.getTime() <= 0) return ""
-  var mins = Math.floor((now.getTime() - date.getTime()) / 60000)
-  if (mins < 1) return "just now"
-  if (mins < 60) return mins + "m ago"
-  var hours = Math.floor(mins / 60)
-  if (hours < 24) return hours + "h ago"
+  var mins = Math.floor((now.getTime() - date.getTime()) / MS_PER_MINUTE)
+  if (mins < 1) return LABEL_JUST_NOW
+  if (mins < MINUTES_PER_HOUR) return mins + "m ago"
+  var hours = Math.floor(mins / MINUTES_PER_HOUR)
+  if (hours < HOURS_PER_DAY) return hours + "h ago"
   return hm(date)
 }
 

--- a/Model.js
+++ b/Model.js
@@ -169,6 +169,8 @@ var MINUTES_PER_HOUR = 60
 var DAYS_PER_WEEK = 7
 var TRANSITION_YEAR_MARGIN = 1
 
+var LABEL_ALL_DAY = "All day"
+
 var TZ_TABLE = {}
 
 // Parse an RFC 5545 UTC offset ([+-]HHMM[SS]) into milliseconds.
@@ -647,6 +649,14 @@ function parseEventBlock(block) {
           : parsed.date.getUTCFullYear() * 10000 + (parsed.date.getUTCMonth() + 1) * 100 + parsed.date.getUTCDate()
       } else {
         ev.end = parsed.date
+        var wallEnd = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})?/.exec(value)
+        ev.tzEndInfo = {
+          utc: parsed.utc,
+          tzid: tzid,
+          h: wallEnd ? parseInt(wallEnd[4], 10) : 0,
+          mi: wallEnd ? parseInt(wallEnd[5], 10) : 0,
+          s: wallEnd && wallEnd[6] ? parseInt(wallEnd[6], 10) : 0
+        }
       }
       lastTzid = tzid
     }
@@ -677,6 +687,20 @@ function parseEventBlock(block) {
   } else {
     ev.durationMs = ev.allDay ? MS_PER_DAY : MS_PER_HOUR
     ev.end = new Date(ev.start.getTime() + ev.durationMs)
+  }
+
+  if (!ev.allDay && ev.start && ev.end) {
+    var dur = ev.end.getTime() - ev.start.getTime()
+    var startIsMidnight = ev.tzInfo
+      ? (ev.tzInfo.h === 0 && ev.tzInfo.mi === 0 && ev.tzInfo.s === 0)
+      : (ev.start.getHours() === 0 && ev.start.getMinutes() === 0 && ev.start.getSeconds() === 0)
+    var endIsMidnight = ev.tzEndInfo
+      ? (ev.tzEndInfo.h === 0 && ev.tzEndInfo.mi === 0 && ev.tzEndInfo.s === 0)
+      : (ev.end.getHours() === 0 && ev.end.getMinutes() === 0 && ev.end.getSeconds() === 0)
+    if (dur >= 23 * 3600000 && startIsMidnight && endIsMidnight) {
+      ev.allDay = true
+      ev.durationMs = dur
+    }
   }
   return ev
 }
@@ -879,12 +903,14 @@ function shortStart(date) {
   return hm(date)
 }
 
-function timeRange(start, end) {
+function timeRange(start, end, allDay) {
+  if (allDay) return LABEL_ALL_DAY
   if (!start) return ""
   return hm(start) + "–" + hm(end)
 }
 
-function meetingTimeLabel(start, end, now) {
+function meetingTimeLabel(start, end, now, allDay) {
+  var isAllDay = allDay === true || (start && end && (end.getTime() - start.getTime()) >= 86400000 && start.getHours() === 0 && start.getMinutes() === 0 && end.getHours() === 0 && end.getMinutes() === 0)
   var labels = []
   if (isSameDay(start, now)) labels.push("Today")
   else if (isSameDay(start, new Date(now.getTime() + MS_PER_DAY))) labels.push("Tomorrow")
@@ -893,12 +919,30 @@ function meetingTimeLabel(start, end, now) {
     var mo = MONTH_NAMES_SHORT[start.getMonth()]
     labels.push(dow + " " + start.getDate() + " " + mo)
   }
-  if (start && end) labels.push(timeRange(start, end))
+  if (isAllDay) {
+    labels.push(LABEL_ALL_DAY)
+  } else if (start && end) {
+    labels.push(timeRange(start, end))
+  }
   return labels.join(" · ")
 }
 
+function isEventAllDay(ev) {
+  if (!ev) return false
+  if (ev.allDay === true) return true
+  if (ev.start && ev.end) {
+    var dur = ev.end.getTime() - ev.start.getTime()
+    if (dur >= 23 * 3600000 &&
+        ev.start.getHours() === 0 && ev.start.getMinutes() === 0 && ev.start.getSeconds() === 0 &&
+        ev.end.getHours() === 0 && ev.end.getMinutes() === 0 && ev.end.getSeconds() === 0) {
+      return true
+    }
+  }
+  return false
+}
+
 function relativeStatus(next, now) {
-  if (!next || !next.start || !next.end) return ""
+  if (!next || !next.start || !next.end || isEventAllDay(next)) return ""
   var start = next.start.getTime()
   var end = next.end.getTime()
   var t = now.getTime()
@@ -940,7 +984,13 @@ function formatLabel(next, now, maxTitleLength) {
   var start = next.start.getTime()
   var end = next.end ? next.end.getTime() : start
   var t = now.getTime()
-  if (t >= start && t < end) {
+  if (isEventAllDay(next)) {
+    if (isSameDay(next.start, now) || (t >= start && t < end)) {
+      suffix = " · " + LABEL_ALL_DAY
+    } else {
+      suffix = " · " + dayLabel(next.start, now) + " " + LABEL_ALL_DAY
+    }
+  } else if (t >= start && t < end) {
     var minsLeft = Math.max(1, Math.round((end - t) / 60000))
     if (minsLeft <= 1) {
       suffix = " · 1 min left"
@@ -963,7 +1013,16 @@ function formatLabel(next, now, maxTitleLength) {
   return title + suffix
 }
 
-function compareUpcoming(a, b) {
+function compareUpcoming(a, b, now) {
+  var todayMs = typeof now === "number" ? now : startOfDay(now || new Date())
+  var aDay = Math.max(startOfDay(a.start), todayMs)
+  var bDay = Math.max(startOfDay(b.start), todayMs)
+  if (aDay !== bDay) return aDay - bDay
+
+  var aAllDay = isEventAllDay(a)
+  var bAllDay = isEventAllDay(b)
+  if (aAllDay !== bAllDay) return aAllDay ? 1 : -1
+
   var av = a.start.getTime(), bv = b.start.getTime()
   if (av !== bv) return av - bv
   var bd = (b.end ? b.end.getTime() : bv) - bv
@@ -990,7 +1049,7 @@ function buildUpcoming(events, now, options) {
     upcoming.push(ev)
   }
 
-  upcoming.sort(compareUpcoming)
+  upcoming.sort(function(a, b) { return compareUpcoming(a, b, now) })
 
   if (upcoming.length > maxRows) upcoming = upcoming.slice(0, maxRows)
   return upcoming
@@ -1031,18 +1090,19 @@ function buildScheduleGroups(events, now, options) {
     if (ev.start.getTime() > horizon) continue
     valid.push(ev)
   }
-  valid.sort(compareUpcoming)
+  valid.sort(function(a, b) { return compareUpcoming(a, b, now) })
   if (valid.length > maxRows) valid = valid.slice(0, maxRows)
 
   var groups = []
   var map = {}
   for (var j = 0; j < valid.length; j++) {
     var item = valid[j]
-    var key = dayKey(item.start.getFullYear(), item.start.getMonth() + 1, item.start.getDate())
+    var groupDate = item.start.getTime() < t ? now : item.start
+    var key = dayKey(groupDate.getFullYear(), groupDate.getMonth() + 1, groupDate.getDate())
     if (!map[key]) {
       var grp = {
         key: key,
-        title: daySectionTitle(item.start, now),
+        title: daySectionTitle(groupDate, now),
         items: []
       }
       map[key] = grp
@@ -1070,7 +1130,7 @@ function upcomingToday(events, now) {
     out.push(ev)
   }
 
-  out.sort(compareUpcoming)
+  out.sort(function(a, b) { return compareUpcoming(a, b, now) })
   return out
 }
 
@@ -1212,6 +1272,9 @@ if (typeof module !== "undefined" && module.exports) {
     zonedToUtc: zonedToUtc,
     splitIcsFeeds: splitIcsFeeds,
     normalizeKey: normalizeKey,
-    dedupeEvents: dedupeEvents
+    dedupeEvents: dedupeEvents,
+    compareUpcoming: compareUpcoming,
+    isEventAllDay: isEventAllDay,
+    LABEL_ALL_DAY: LABEL_ALL_DAY
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -489,7 +489,7 @@ Panel {
                     visible: !!root.next
                     text: {
                       var parts = []
-                      var dur = root.next ? Model.formatDuration(root.next.start, root.next.end) : ""
+                      var dur = root.next ? (root.next.allDay ? Model.LABEL_ALL_DAY : Model.formatDuration(root.next.start, root.next.end)) : ""
                       if (dur) parts.push(dur)
                       if (root.next) parts.push(root.next.meetUrl ? "  " + Model.meetLabel(root.next.meetUrl) : "󰃯  Event")
                       return parts.join("  ·  ")
@@ -514,7 +514,7 @@ Panel {
                 Text {
                   width: parent.width
                   text: root.next
-                    ? Model.meetingTimeLabel(root.next.start, root.next.end, root.now)
+                    ? Model.meetingTimeLabel(root.next.start, root.next.end, root.now, root.next.allDay)
                       + (Model.relativeStatus(root.next, root.now) ? " · " + Model.relativeStatus(root.next, root.now) : "")
                     : ""
                   color: Qt.darker(root.contentForeground, 1.35)
@@ -703,7 +703,7 @@ Panel {
                             Layout.alignment: tagPill.visible ? Qt.AlignTop : Qt.AlignVCenter
                             Layout.topMargin: tagPill.visible ? Style.space(1) : 0
                             Layout.preferredWidth: Style.space(44)
-                            text: Model.hm(meeting.start)
+                            text: meeting.allDay ? Model.LABEL_ALL_DAY : Model.hm(meeting.start)
                             color: Qt.darker(root.contentForeground, 1.3)
                             font.family: root.contentFontFamily
                             font.pixelSize: Style.font.bodySmall
@@ -757,7 +757,7 @@ Panel {
                             Layout.topMargin: tagPill.visible ? Style.space(1) : 0
                             Layout.preferredWidth: Style.space(34)
                             horizontalAlignment: Text.AlignRight
-                            text: Model.formatDuration(meeting.start, meeting.end)
+                            text: meeting.allDay ? "" : Model.formatDuration(meeting.start, meeting.end)
                             color: Qt.darker(root.contentForeground, 1.6)
                             font.family: root.contentFontFamily
                             font.pixelSize: Style.font.caption

--- a/test/prioritize-events.test.js
+++ b/test/prioritize-events.test.js
@@ -1,0 +1,308 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const Model = require("../Model.js")
+
+test("prioritizes short/timed events over all-day events on the same day", () => {
+  const now = new Date(2026, 7, 27, 8, 0, 0) // 2026-08-27 08:00:00
+
+  const allDayEvent = {
+    uid: "allday-1",
+    title: "All Day Hackathon",
+    start: new Date(2026, 7, 27, 0, 0, 0),
+    end: new Date(2026, 7, 28, 0, 0, 0),
+    allDay: true
+  }
+
+  const shortEvent = {
+    uid: "short-1",
+    title: "Morning Standup",
+    start: new Date(2026, 7, 27, 9, 30, 0),
+    end: new Date(2026, 7, 27, 9, 45, 0),
+    allDay: false
+  }
+
+  const events = [allDayEvent, shortEvent]
+
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 2)
+  assert.equal(upcoming[0].title, "Morning Standup")
+  assert.equal(upcoming[1].title, "All Day Hackathon")
+
+  const todayList = Model.upcomingToday(events, now)
+  assert.equal(todayList.length, 2)
+  assert.equal(todayList[0].title, "Morning Standup")
+  assert.equal(todayList[1].title, "All Day Hackathon")
+})
+
+test("chooses all-day event when there is no short event", () => {
+  const now = new Date(2026, 7, 27, 8, 0, 0)
+
+  const allDayEvent = {
+    uid: "allday-1",
+    title: "Company Holiday",
+    start: new Date(2026, 7, 27, 0, 0, 0),
+    end: new Date(2026, 7, 28, 0, 0, 0),
+    allDay: true
+  }
+
+  const events = [allDayEvent]
+
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 1)
+  assert.equal(upcoming[0].title, "Company Holiday")
+})
+
+test("switches to all-day event after short events for the day have finished", () => {
+  const allDayEvent = {
+    uid: "allday-1",
+    title: "Company Holiday",
+    start: new Date(2026, 7, 27, 0, 0, 0),
+    end: new Date(2026, 7, 28, 0, 0, 0),
+    allDay: true
+  }
+
+  const shortEvent = {
+    uid: "short-1",
+    title: "Morning Standup",
+    start: new Date(2026, 7, 27, 9, 30, 0),
+    end: new Date(2026, 7, 27, 9, 45, 0),
+    allDay: false
+  }
+
+  const events = [allDayEvent, shortEvent]
+
+  // At 10:00 (after standup ended at 09:45)
+  const afterStandup = new Date(2026, 7, 27, 10, 0, 0)
+  const upcoming = Model.buildUpcoming(events, afterStandup, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 1)
+  assert.equal(upcoming[0].title, "Company Holiday")
+})
+
+test("prioritizes today's all-day event over tomorrow's timed event", () => {
+  const now = new Date(2026, 7, 27, 18, 0, 0) // today 18:00
+
+  const todayAllDay = {
+    uid: "allday-today",
+    title: "Today All Day Event",
+    start: new Date(2026, 7, 27, 0, 0, 0),
+    end: new Date(2026, 7, 28, 0, 0, 0),
+    allDay: true
+  }
+
+  const tomorrowTimed = {
+    uid: "timed-tmrw",
+    title: "Tomorrow Morning Sync",
+    start: new Date(2026, 7, 28, 9, 0, 0),
+    end: new Date(2026, 7, 28, 10, 0, 0),
+    allDay: false
+  }
+
+  const events = [tomorrowTimed, todayAllDay]
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 2)
+  assert.equal(upcoming[0].title, "Today All Day Event")
+  assert.equal(upcoming[1].title, "Tomorrow Morning Sync")
+})
+
+test("prioritizes tomorrow's timed event over tomorrow's all-day event", () => {
+  const now = new Date(2026, 7, 27, 18, 0, 0)
+
+  const tomorrowAllDay = {
+    uid: "allday-tmrw",
+    title: "Tomorrow All Day Event",
+    start: new Date(2026, 7, 28, 0, 0, 0),
+    end: new Date(2026, 7, 29, 0, 0, 0),
+    allDay: true
+  }
+
+  const tomorrowTimed = {
+    uid: "timed-tmrw",
+    title: "Tomorrow Morning Sync",
+    start: new Date(2026, 7, 28, 9, 0, 0),
+    end: new Date(2026, 7, 28, 10, 0, 0),
+    allDay: false
+  }
+
+  const events = [tomorrowAllDay, tomorrowTimed]
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 2)
+  assert.equal(upcoming[0].title, "Tomorrow Morning Sync")
+  assert.equal(upcoming[1].title, "Tomorrow All Day Event")
+})
+
+test("prioritizes short events over ongoing multi-day all-day events", () => {
+  const now = new Date(2026, 7, 27, 10, 0, 0) // Thursday
+
+  const multiDayAllDay = {
+    uid: "multiday-1",
+    title: "Multi-Day Conference",
+    start: new Date(2026, 7, 25, 0, 0, 0), // started Tuesday
+    end: new Date(2026, 7, 29, 0, 0, 0),   // ends Saturday
+    allDay: true
+  }
+
+  const todayShortEvent = {
+    uid: "short-today",
+    title: "Afternoon Meeting",
+    start: new Date(2026, 7, 27, 14, 0, 0),
+    end: new Date(2026, 7, 27, 15, 0, 0),
+    allDay: false
+  }
+
+  const events = [multiDayAllDay, todayShortEvent]
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 2)
+  assert.equal(upcoming[0].title, "Afternoon Meeting")
+  assert.equal(upcoming[1].title, "Multi-Day Conference")
+})
+
+test("formats labels appropriately for all-day events", () => {
+  const now = new Date(2026, 7, 27, 10, 0, 0)
+
+  const todayAllDay = {
+    uid: "allday-1",
+    title: "Hackathon",
+    start: new Date(2026, 7, 27, 0, 0, 0),
+    end: new Date(2026, 7, 28, 0, 0, 0),
+    allDay: true
+  }
+
+  const tmrwAllDay = {
+    uid: "allday-2",
+    title: "Offsite",
+    start: new Date(2026, 7, 28, 0, 0, 0),
+    end: new Date(2026, 7, 29, 0, 0, 0),
+    allDay: true
+  }
+
+  assert.equal(Model.formatLabel(todayAllDay, now, 30), "Hackathon · All day")
+  assert.equal(Model.formatLabel(tmrwAllDay, now, 30), "Offsite · Tmrw All day")
+  assert.equal(Model.relativeStatus(todayAllDay, now), "")
+  assert.equal(Model.timeRange(todayAllDay.start, todayAllDay.end, todayAllDay.allDay), "All day")
+  assert.equal(Model.meetingTimeLabel(todayAllDay.start, todayAllDay.end, now, todayAllDay.allDay), "Today · All day")
+  assert.equal(Model.meetingTimeLabel(tmrwAllDay.start, tmrwAllDay.end, now, tmrwAllDay.allDay), "Tomorrow · All day")
+})
+
+test("buildScheduleGroups orders timed events before all-day events within day groups", () => {
+  const now = new Date(2026, 7, 27, 8, 0, 0)
+
+  const allDay = {
+    uid: "allday-1",
+    title: "Hackathon",
+    start: new Date(2026, 7, 27, 0, 0, 0),
+    end: new Date(2026, 7, 28, 0, 0, 0),
+    allDay: true
+  }
+
+  const timed1 = {
+    uid: "timed-1",
+    title: "Standup",
+    start: new Date(2026, 7, 27, 9, 0, 0),
+    end: new Date(2026, 7, 27, 9, 30, 0),
+    allDay: false
+  }
+
+  const timed2 = {
+    uid: "timed-2",
+    title: "Retro",
+    start: new Date(2026, 7, 27, 15, 0, 0),
+    end: new Date(2026, 7, 27, 16, 0, 0),
+    allDay: false
+  }
+
+  const groups = Model.buildScheduleGroups([allDay, timed2, timed1], now, { lookaheadDays: 3 })
+  assert.equal(groups.length, 1)
+  assert.equal(groups[0].title, "TODAY")
+  assert.equal(groups[0].items.length, 3)
+  assert.equal(groups[0].items[0].title, "Standup")
+  assert.equal(groups[0].items[1].title, "Retro")
+  assert.equal(groups[0].items[2].title, "Hackathon")
+})
+
+test("parseIcs and buildUpcoming with ICS containing all-day and timed events", () => {
+  const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:allday-event@test
+DTSTART;VALUE=DATE:20260824
+DTEND;VALUE=DATE:20260825
+SUMMARY:Conference Day
+END:VEVENT
+BEGIN:VEVENT
+UID:timed-event@test
+DTSTART:20260824T140000
+DTEND:20260824T150000
+SUMMARY:Project Sync
+LOCATION:https://meet.google.com/abc-defg-hij
+END:VEVENT
+END:VCALENDAR`
+
+  const now = new Date(2026, 7, 24, 10, 0, 0)
+  const events = Model.parseIcs(ics, { now: now, lookaheadDays: 3 })
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+
+  assert.equal(upcoming.length, 2)
+  assert.equal(upcoming[0].title, "Project Sync")
+  assert.equal(upcoming[1].title, "Conference Day")
+})
+
+test("identifies midnight-to-midnight datetime events as all-day events", () => {
+  const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:allday-midnight@test
+DTSTART:20260824T000000
+DTEND:20260825T000000
+SUMMARY:Full Day Off
+END:VEVENT
+BEGIN:VEVENT
+UID:timed-standup@test
+DTSTART:20260824T100000
+DTEND:20260824T103000
+SUMMARY:Team Standup
+END:VEVENT
+END:VCALENDAR`
+
+  const now = new Date(2026, 7, 24, 8, 0, 0)
+  const events = Model.parseIcs(ics, { now: now, lookaheadDays: 3 })
+  assert.equal(events[0].allDay, true)
+  assert.equal(events[1].allDay, false)
+
+  const upcoming = Model.buildUpcoming(events, now, { showOnlyWithVideoLink: false })
+  assert.equal(upcoming.length, 2)
+  assert.equal(upcoming[0].title, "Team Standup")
+  assert.equal(upcoming[1].title, "Full Day Off")
+})
+
+test("does not treat short midnight-starting events as all-day", () => {
+  const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:timed-midnight@test
+DTSTART:20260824T000000
+DTEND:20260824T010000
+SUMMARY:System Maintenance
+END:VEVENT
+END:VCALENDAR`
+
+  const now = new Date(2026, 7, 23, 23, 0, 0)
+  const events = Model.parseIcs(ics, { now: now, lookaheadDays: 3 })
+  assert.equal(events[0].allDay, false)
+})
+
+test("does not treat 24-hour non-midnight events as all-day", () => {
+  const ics = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:timed-hackathon@test
+DTSTART:20260824T140000
+DTEND:20260825T140000
+SUMMARY:24h Hackathon
+END:VEVENT
+END:VCALENDAR`
+
+  const now = new Date(2026, 7, 24, 10, 0, 0)
+  const events = Model.parseIcs(ics, { now: now, lookaheadDays: 3 })
+  assert.equal(events[0].allDay, false)
+})
+


### PR DESCRIPTION
Closes #19

### Summary

When both all-day and short/timed events are present on a day, all-day events were previously prioritized as the `nextMeeting` because their start time was `00:00`, shadowing upcoming short events throughout the day.

This PR:
- Updates `compareUpcoming` in `Model.js` to prioritize short/timed events over all-day events on the same calendar day while preserving chronological day ordering.
- Updates `formatLabel` and `meetingTimeLabel` to format all-day events as `"All day"` without countdowns or `00:00–00:00` ranges.
- Excludes all-day events from `inMeeting` active state in `BarWidget.qml`.
- Updates `Panel.qml` schedule list and hero item to display `"All day"` for all-day events.
- Adds test suite in `test/prioritize-events.test.js`.