### PR TITLE
fix: handle date-only iCal values as UTC for timezone consistency

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -248,6 +248,7 @@ class DateTimeUtils {
   }
 
   static isSameDay(dateA, dateB) {
+    if (!dateA || !dateB) return false
     return (
       dateA.getFullYear() === dateB.getFullYear() &&
       dateA.getMonth() === dateB.getMonth() &&
@@ -309,6 +310,15 @@ class DateTimeUtils {
         utc: false,
         allDay: isDateOnly,
         tzid: tzid
+      }
+    }
+    // For date-only values (VALUE=DATE in iCal), treat as UTC date to handle
+    // timezone differences between calendar provider and local system
+    if (isDateOnly) {
+      return {
+        date: new Date(Date.UTC(year, month - 1, day)),
+        utc: true,
+        allDay: isDateOnly
       }
     }
     return {

--- a/test/DateTimeUtils.test.js
+++ b/test/DateTimeUtils.test.js
@@ -29,6 +29,13 @@ describe("DateTimeUtils", () => {
       const d3 = new Date(2026, 7, 29, 10, 0, 0)
       assert.strictEqual(DateTimeUtils.isSameDay(d1, d3), false)
     })
+
+    it("returns false when dateA or dateB is null or undefined", () => {
+      assert.strictEqual(DateTimeUtils.isSameDay(null, new Date()), false)
+      assert.strictEqual(DateTimeUtils.isSameDay(new Date(), null), false)
+      assert.strictEqual(DateTimeUtils.isSameDay(undefined, new Date()), false)
+      assert.strictEqual(DateTimeUtils.isSameDay(new Date(), undefined), false)
+    })
   })
 
   describe("daysInMonthUTC()", () => {
@@ -92,6 +99,12 @@ describe("DateTimeUtils", () => {
       assert.strictEqual(parsed.date.getFullYear(), 2026)
       assert.strictEqual(parsed.date.getMonth(), 7)
       assert.strictEqual(parsed.date.getDate(), 28)
+    })
+
+    it("parses date-only values as UTC to handle timezone consistency", () => {
+      const parsed = DateTimeUtils.parseRfcDate("20260828")
+      assert.strictEqual(parsed.utc, true)
+      assert.strictEqual(parsed.date.toISOString(), "2026-08-28T00:00:00.000Z")
     })
 
     it("returns null for malformed or empty date strings", () => {

--- a/test/DisplayFormatter.test.js
+++ b/test/DisplayFormatter.test.js
@@ -182,6 +182,20 @@ describe("DisplayFormatter", () => {
       )
     })
 
+    it("formats tomorrow's all-day event with UTC date from iCal", () => {
+      const utcTomorrow = new CalendarEvent({
+        uid: "utc-tmrw",
+        title: "UTC Event",
+        start: new Date(Date.UTC(2026, 7, 29)),
+        end: new Date(Date.UTC(2026, 7, 30)),
+        allDay: true
+      })
+      assert.strictEqual(
+        DisplayFormatter.formatLabel(utcTomorrow, now, 30),
+        "UTC Event · Tmrw All day"
+      )
+    })
+
     it("truncates long titles exceeding maxTitleLength", () => {
       const longEvent = new CalendarEvent({
         title: "Very Long Team Meeting With Many Words",


### PR DESCRIPTION
Fix issue where all-day events from iCal feeds (VALUE=DATE format) were being displayed on the wrong day due to timezone inconsistencies.

Google Calendar exports all-day events as date-only values (e.g., DTSTART;VALUE=DATE:20260904). The plugin was parsing these as local time dates, which could cause the event to be displayed one day early when there was a timezone mismatch between the calendar provider and the local system.

This fix treats date-only values as UTC dates, ensuring consistent timezone handling across different calendar providers. This ensures all-day events are correctly interpreted and displayed on the proper day.

Additionally:
- Added null safety check to isSameDay() function
- Added test cases for UTC date handling and null checks

Done with the help of Mistral Vibe.