### PR TITLE
perf: request gzip for ICS calendar downloads

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -150,7 +150,7 @@ BarWidget {
       return
     }
     fetchProc.stdinEnabled = true
-    fetchProc.command = ["curl", "-fsSL", "--max-time", String(Model.FETCH_TIMEOUT_SECONDS), "--max-filesize", String(root.maxFeedSizeMiB * Model.BYTES_PER_MIB), "-K", "-"]
+    fetchProc.command = ["curl", "-fsSL", "--compressed", "--max-time", String(Model.FETCH_TIMEOUT_SECONDS), "--max-filesize", String(root.maxFeedSizeMiB * Model.BYTES_PER_MIB), "-K", "-"]
     fetchProc.running = true
   }
 


### PR DESCRIPTION
## Why

Google Calendar private ICS feeds can be 20 MiB+ uncompressed (full history). NextEvent only needs the next few days, but still downloads the whole file on every refresh.

`curl --compressed` asks for gzip. Servers that do not gzip ignore `Accept-Encoding` and send the raw body, so this is a no-op there. `file://` feeds are unchanged.

`--max-filesize` still applies to the decompressed body, so the existing `maxFeedSizeMiB` cap remains the gzip-bomb limit.

## Benchmark

Timed against real Google Calendar private ICS feeds (`curl` 8.21, same machine):

| Feed | Encoding | Wire size | Uncompressed | Wall | TTFB |
| --- | --- | ---: | ---: | ---: | ---: |
| Work | identity | 20.14 MiB (21,116,808 B) | 20.14 MiB | 25.5s | 16.5s |
| Work | gzip | **3.19 MiB (3,347,664 B)** | 20.14 MiB | 18.6s | 17.5s |
| Personal | identity | 2.18 MiB | 2.18 MiB | 3.6s | 2.7s |
| Personal | gzip | **0.49 MiB (509,074 B)** | 2.18 MiB | 2.7s | 2.2s |

Work feed is ~6.3× smaller on the wire (20.14 MiB → 3.19 MiB). Most of the remaining wall time is Google TTFB (~16–17s), not transfer.

## Change

Add `--compressed` to the ICS `curl` invocation in `BarWidget.qml`. Always on; no new setting.

## Test plan

- [x] Timed work + personal Google ICS with and without `--compressed` (table above)
- [x] Confirm bar still shows upcoming events after refresh — `file://` demo fixtures rendered `Live Incident · 35 min left` on the bar with this checkout loaded
- [x] Confirm a `file://` demo feed still loads — `curl --compressed file://…/demo.ics` returned the identical body (3,323 B); Omarchy bar picked up the demo events
- [x] `npm test` — 138 passed

Note: the widget's `--max-time 15` still cannot finish the 20 MiB work feed because Google TTFB is ~16–17s with or without gzip. Personal gzip fetch succeeds in ~2.4s. That timeout is pre-existing and unchanged by this PR.