### PR TITLE
feat: show cached ICS events immediately on startup

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -21,6 +21,7 @@ BarWidget {
   // (comma-separated), or a JSON array of strings / { url, label } objects.
   readonly property var icsFeeds: Model.splitIcsFeeds(setting("icsUrl", ""))
   readonly property string eventsJsonPath: String(setting("eventsJsonPath", (Quickshell.env("HOME") || "") + "/.local/state/omarchy/calendar-events.json") || "").trim()
+  readonly property string icsCachePath: (Quickshell.env("HOME") || "") + "/.local/state/omarchy/next-event-cache.json"
   readonly property string sourceMode: String(setting("sourceMode", icsFeeds.length > 0 ? Model.SOURCE_MODE_ICS : Model.SOURCE_MODE_JSON) || "").trim()
   readonly property int refreshMinutes: Math.max(1, parseInt(setting("refreshMinutes", Model.DEFAULT_REFRESH_MINUTES), 10) || Model.DEFAULT_REFRESH_MINUTES)
   readonly property int showDaysAhead: Math.max(1, parseInt(setting("showDaysAhead", Model.DEFAULT_LOOKAHEAD_DAYS), 10) || Model.DEFAULT_LOOKAHEAD_DAYS)
@@ -52,9 +53,11 @@ BarWidget {
 
   // ---- state
   property bool jsonLoaded: false
+  property bool icsLiveFetchSucceeded: false
   readonly property bool configured: (sourceMode === Model.SOURCE_MODE_ICS ? icsFeeds.length > 0 : jsonLoaded) || (rawEvents && rawEvents.length > 0)
   onSourceModeChanged: {
     jsonLoaded = false
+    icsLiveFetchSucceeded = false
     fetchCalendar()
   }
   property var rawEvents: []
@@ -210,15 +213,37 @@ BarWidget {
     var events = Model.dedupeEvents(allEvents)
 
     if (events.length === 0 && root.offlineFeedCount > 0 && root.feedChunks.length === 0) {
-      // Every feed failed: no data at all.
-      root.rawEvents = []
+      // Every feed failed: keep any cached snapshot on screen.
       root.lastFetchFailed = true
       root.meetingDataChanged()
       return
     }
 
     root.lastFetchFailed = false
+    root.icsLiveFetchSucceeded = true
     root.applyScheduleState(events, new Date())
+    root.writeIcsCache()
+  }
+
+  function onIcsCacheLoaded(raw) {
+    if (root.sourceMode !== Model.SOURCE_MODE_ICS) return
+    if (root.icsFeeds.length === 0) return
+    if (root.icsLiveFetchSucceeded) return
+    var text = String(raw || "").trim()
+    if (!text) return
+    var parsed = Model.parseJsonState(text, {
+      lookaheadDays: root.showDaysAhead + 1,
+      now: root.now
+    })
+    if (!parsed.events || parsed.events.length === 0) return
+    var cachedAt = parsed.syncedAt ? new Date(parsed.syncedAt) : null
+    if (cachedAt && isNaN(cachedAt.getTime())) cachedAt = null
+    root.applyScheduleState(parsed.events, cachedAt)
+  }
+
+  function writeIcsCache() {
+    if (root.sourceMode !== Model.SOURCE_MODE_ICS) return
+    icsCacheFile.setText(Model.serializeIcsCache(root.rawEvents, root.lastUpdated))
   }
 
   function onJsonData(raw) {
@@ -318,6 +343,15 @@ BarWidget {
       console.warn("NextEvent: eventsJson load failed: " + error + " path=" + root.eventsJsonPath)
     }
     onFileChanged: reload()
+  }
+
+  FileView {
+    id: icsCacheFile
+    path: root.sourceMode === Model.SOURCE_MODE_ICS ? root.icsCachePath : ""
+    watchChanges: false
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root.onIcsCacheLoaded(text())
   }
 
   Process {

--- a/Model.js
+++ b/Model.js
@@ -1434,6 +1434,43 @@ class JsonStateParser {
     var events = JsonStateParser.parseJsonEvents(jsonDocument, options)
     return { events: events, syncedAt: jsonDocument.syncedAt || null }
   }
+
+  static dateToIso(value) {
+    if (value == null || value === "") return null
+    if (typeof value === "string") return value
+    try {
+      if (typeof value.toISOString === "function") return value.toISOString()
+    } catch (_) {
+      return null
+    }
+    return null
+  }
+
+  static serializeIcsCache(events, syncedAt) {
+    var list = []
+    var source = events || []
+    for (var i = 0; i < source.length; i++) {
+      var event = source[i]
+      if (!event) continue
+      var start = JsonStateParser.dateToIso(event.start)
+      if (!start) continue
+      list.push({
+        uid: event.uid || null,
+        title: event.title || DEFAULT_EVENT_TITLE,
+        start: start,
+        end: JsonStateParser.dateToIso(event.end),
+        allDay: event.allDay === true,
+        meetUrl: event.meetUrl || null,
+        location: event.location || "",
+        calendarName: event.calendarName || "",
+        feedLabel: event.feedLabel || null,
+        calendarColor: event.calendarColor || null,
+        eventUrl: event.eventUrl || null
+      })
+    }
+    var synced = JsonStateParser.dateToIso(syncedAt) || JsonStateParser.dateToIso(new Date())
+    return JSON.stringify({ syncedAt: synced, events: list })
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2225,6 +2262,9 @@ function parseJsonEvents(items, options) {
 function parseJsonState(rawText, options) {
   return JsonStateParser.parseJsonState(rawText, options)
 }
+function serializeIcsCache(events, syncedAt) {
+  return JsonStateParser.serializeIcsCache(events, syncedAt)
+}
 
 function splitIcsFeeds(raw) {
   return FeedConfigParser.splitIcsFeeds(raw)
@@ -2368,6 +2408,7 @@ if (typeof module !== "undefined" && module.exports) {
     parseIcs: parseIcs,
     parseJsonEvents: parseJsonEvents,
     parseJsonState: parseJsonState,
+    serializeIcsCache: serializeIcsCache,
     splitIcsFeeds: splitIcsFeeds,
     dedupeEvents: dedupeEvents,
     normalizeKey: normalizeKey,

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ upcoming event from your calendar with live countdowns and lets you join video c
 - **Summon Keybinding**: Bind a global key to open the agenda panel (see [Opening the panel from the keyboard](#opening-the-panel-from-the-keyboard))
 - **Repeating Events**: Automatically expands repeating events (daily standups, weekly meetings) and respects cancelled or rescheduled instances
 - **Live Updates**: Automatic background sync every few minutes, with a 30-second reactive countdown timer
+- **Instant start**: ICS events reappear immediately from a local cache while calendars refresh in the background
 
 ## Install
 
@@ -213,7 +214,7 @@ browser; refreshing keeps it open.
 
 ## Privacy
 
-Calendar data is fetched directly by your machine. No external intermediate service, no 3rd-party servers, no telemetry.
+Calendar data is fetched directly by your machine. No external intermediate service, no 3rd-party servers, no telemetry. ICS snapshots are cached locally at `~/.local/state/omarchy/next-event-cache.json` (event details only — feed URLs are never written).
 
 ## Contributing
 

--- a/test/JsonStateParser.test.js
+++ b/test/JsonStateParser.test.js
@@ -85,4 +85,58 @@ describe("JsonStateParser", () => {
       assert.deepStrictEqual(state, { events: [], syncedAt: null })
     })
   })
+
+  describe("serializeIcsCache()", () => {
+    it("round-trips events through serializeIcsCache / parseJsonState", () => {
+      const events = [
+        {
+          uid: "e1",
+          title: "Standup",
+          start: new Date("2026-08-28T10:00:00.000Z"),
+          end: new Date("2026-08-28T10:15:00.000Z"),
+          allDay: false,
+          meetUrl: "https://meet.google.com/abc-defg-hij",
+          feedLabel: "Work",
+          calendarColor: "#4285f4",
+          location: "Room A"
+        }
+      ]
+
+      const raw = JsonStateParser.serializeIcsCache(events, new Date("2026-08-28T09:00:00.000Z"))
+      const parsed = JsonStateParser.parseJsonState(raw)
+
+      assert.strictEqual(parsed.syncedAt, "2026-08-28T09:00:00.000Z")
+      assert.strictEqual(parsed.events.length, 1)
+      assert.strictEqual(parsed.events[0].uid, "e1")
+      assert.strictEqual(parsed.events[0].title, "Standup")
+      assert.strictEqual(parsed.events[0].calendarColor, "#4285f4")
+      assert.strictEqual(parsed.events[0].feedLabel, "Work")
+      assert.strictEqual(parsed.events[0].meetUrl, "https://meet.google.com/abc-defg-hij")
+      assert.strictEqual(parsed.events[0].start.toISOString(), "2026-08-28T10:00:00.000Z")
+      assert.strictEqual(parsed.events[0].end.toISOString(), "2026-08-28T10:15:00.000Z")
+    })
+
+    it("does not persist feed URLs in the cache payload", () => {
+      const raw = JsonStateParser.serializeIcsCache(
+        [
+          {
+            title: "Secret",
+            start: new Date("2026-08-28T10:00:00.000Z"),
+            url: "https://calendar.google.com/calendar/ical/private-secret/basic.ics"
+          }
+        ],
+        new Date("2026-08-28T09:00:00.000Z")
+      )
+
+      assert.strictEqual(raw.includes("private-secret"), false)
+      assert.strictEqual(raw.includes("basic.ics"), false)
+    })
+
+    it("serializes an empty event list with a syncedAt timestamp", () => {
+      const raw = JsonStateParser.serializeIcsCache(null, new Date("2026-08-28T09:00:00.000Z"))
+      const parsed = JSON.parse(raw)
+      assert.deepStrictEqual(parsed.events, [])
+      assert.strictEqual(parsed.syncedAt, "2026-08-28T09:00:00.000Z")
+    })
+  })
 })


### PR DESCRIPTION
## Why

Restarting the shell (or the widget) blanks the bar until every ICS feed redownloads. That can take many seconds, so the next event disappears even though we already fetched it moments ago.

## Change

Persist the last parsed ICS snapshot to `~/.local/state/omarchy/next-event-cache.json` and render it immediately on startup, then refresh in the background (stale-while-revalidate).

- Cache stores event details only — feed URLs are credentials and are never written
- A live fetch that succeeds replaces the snapshot
- If every feed fails, keep the cached events on screen instead of clearing the bar
- A live fetch that finishes first is not overwritten by a late cache load

## Test plan

- [x] `npm test` — 141 passed
- [x] `npm run lint`
- [x] First shell restart after a successful fetch writes the cache
- [x] Second restart shows the next event instantly, then refreshes in the background